### PR TITLE
release workflow도 pnpm 8 버전으로 고정합니다

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,11 +20,11 @@ jobs:
               with:
                   node-version: 20.x
 
-            - name: Install pnpm
-              run: npm i -g pnpm
-
-            - name: Install Dependencies
-              run: pnpm install --frozen-lockfile
+            - name: Install dependencies
+              uses: pnpm/action-setup@v3
+              with:
+                  version: 8
+                  run_install: true
 
             - name: Create Release Pull Request or Publish to npm
               id: changesets


### PR DESCRIPTION
## Related Issue <!-- #뒤에 이슈번호 작성 -->

-

## Describe your changes <!-- PR의 주요 작업 내용 작성 -->

- 현재 pnpm v8 기반으로 pnpm-lock file이 작성되어 있습니다.
- release workflow도 pnpm 8 버전으로 고정합니다

## Request <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->

-
