### PR TITLE
svg-manager 이관

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -19,7 +19,7 @@ const packageJsonList = glob
             /** size limit config 기본값 */
             name,
             path: `packages/${packageName}${main.slice(1)}`,
-            limit: '500 ms',
+            limit: '1 s',
 
             /** 패키지 내부에 추가되어 있는 값
              * @see https://github.com/ai/size-limit

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "@naverpay/markdown-lint": "^0.0.2",
         "@naverpay/prettier-config": "^0.0.2",
         "@size-limit/preset-big-lib": "^11.0.2",
+        "core-js": "^3.29.0",
         "glob": "^9.3.4",
         "husky": "^8.0.3",
         "lint-staged": "^15.0.1",

--- a/packages/react-pdf/package.json
+++ b/packages/react-pdf/package.json
@@ -25,7 +25,6 @@
     },
     "devDependencies": {
         "rollup": "^2.79.1",
-        "core-js": "^3.29.0",
         "@naverpay/tsconfig": "workspace:^",
         "@naverpay/rollup": "workspace:^",
         "@types/react": "^18.2.75",

--- a/packages/svg-manager/README.md
+++ b/packages/svg-manager/README.md
@@ -1,0 +1,17 @@
+# @naverpay/svg-manager
+
+React로 작성된 svg 컴포넌트의 공통 인터페이스를 제공합니다.
+
+## Installation
+
+```sh
+npm install @naverpay/svg-manager
+```
+
+## Modules
+
+| Name                                 | Description                                           | Type      |
+| :----------------------------------- | :---------------------------------------------------- | :-------- |
+| SVGStyleProps                        | svg 컴포넌트의 Props Type                             | interface |
+| [SvgUniqueID](./docs/SvgUniqueID.md) | svg 컴포넌트에 unique id attribute를 할당하는 Wrapper | component |
+| toSingleton                          | 싱글톤 객체를 생성하는 유틸 함수                      | function  |

--- a/packages/svg-manager/docs/SvgUniqueID.md
+++ b/packages/svg-manager/docs/SvgUniqueID.md
@@ -1,0 +1,30 @@
+# SvgUniqueID
+
+svg 컴포넌트 내부 요소의 id가 동일한 경우, 동일한 영역에서 svg 컴포넌트를 여러 번 사용할 때 `<svg>` 내부 요소가 제대로 그려지지 않을 수 있습니다.
+
+SvgUniqueID는 이러한 id 중복 문제를 피하기 위한 Wrapper 컴포넌트로, svg 컴포넌트 내부 요소에 동적으로 id를 할당할 수 있습니다.
+
+<img src="https://github.com/NaverPayDev/pie/assets/52737532/bc12bef1-8887-4d42-b918-2668a18af74f" width="300" alt="svg example"/>
+
+## Usage
+
+```tsx
+import {SvgUniqueID} from '@naverpay/svg-manager'
+import type {SVGStyleProps} from '@naverpay/svg-manager'
+
+function Logo({width, height, viewBox, id, style}: SVGStyleProps) {
+    return (
+        <SvgUniqueID id={id}>
+            <svg width={width} height={height} viewBox={viewBox} style={style}>
+                <g id="Group">
+                    <g id="Group_2">
+                        <g id="Group_3">...</g>
+                    </g>
+                </g>
+            </svg>
+        </SvgUniqueID>
+    )
+}
+```
+
+![img2](https://github.com/NaverPayDev/pie/assets/52737532/968013a2-ac1b-40b9-8875-cbcb32d092be)

--- a/packages/svg-manager/package.json
+++ b/packages/svg-manager/package.json
@@ -1,0 +1,41 @@
+{
+    "name": "@naverpay/svg-manager",
+    "version": "0.0.1",
+    "main": "./dist/cjs/index.js",
+    "module": "./dist/esm/index.js",
+    "exports": {
+        ".": {
+            "require": "./dist/cjs/index.js",
+            "import": "./dist/esm/index.mjs",
+            "types": "./dist/cjs/index.d.ts"
+        },
+        "./package.json": "./package.json"
+    },
+    "keywords": [
+        "naver",
+        "naverpay",
+        "svg",
+        "svg-manager"
+    ],
+    "author": "@NaverPayDev/frontend",
+    "scripts": {
+        "clean": "rm -rf dist",
+        "build-declarations": "tsc --declaration --emitDeclarationOnly --declarationDir dist/cjs",
+        "build": "npm run clean && npm run build-declarations && rollup -c"
+    },
+    "files": [
+        "dist"
+    ],
+    "devDependencies": {
+        "@naverpay/rollup": "workspace:^",
+        "@naverpay/tsconfig": "workspace:^",
+        "@types/react": "^18.2.75",
+        "csstype": "^3.1.3",
+        "rollup": "^2.79.1"
+    },
+    "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
+    },
+    "license": "MIT"
+}

--- a/packages/svg-manager/package.json
+++ b/packages/svg-manager/package.json
@@ -37,5 +37,8 @@
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
     },
-    "license": "MIT"
+    "license": "MIT",
+    "size-limit": {
+        "limit": "10 kB"
+    }
 }

--- a/packages/svg-manager/package.json
+++ b/packages/svg-manager/package.json
@@ -20,7 +20,7 @@
     "author": "@NaverPayDev/frontend",
     "scripts": {
         "clean": "rm -rf dist",
-        "build-declarations": "tsc --declaration --emitDeclarationOnly --declarationDir dist/cjs",
+        "build-declarations": "tsc",
         "build": "npm run clean && npm run build-declarations && rollup -c"
     },
     "files": [

--- a/packages/svg-manager/rollup.config.js
+++ b/packages/svg-manager/rollup.config.js
@@ -1,0 +1,8 @@
+import {generateRollupConfig} from '@naverpay/rollup'
+
+module.exports = generateRollupConfig({
+    packageDir: __dirname,
+    entrypoint: './src/index.ts',
+    minify: false,
+    react: {runtime: 'automatic'},
+})

--- a/packages/svg-manager/src/SvgUniqueID.tsx
+++ b/packages/svg-manager/src/SvgUniqueID.tsx
@@ -1,0 +1,96 @@
+import {PropsWithChildren, ReactElement, cloneElement} from 'react'
+
+import {generateRandomString, toSingleton} from './utils'
+import deepMap from './utils/deepMap'
+
+const reactRecursiveChildrenMap = deepMap.bind(deepMap)
+
+const generateLocalIdMap = toSingleton(() => new Map<string, number>())
+const localIdsMap = generateLocalIdMap()
+
+const SvgUniqueID = ({
+    children,
+    prefixId = '__SVG_ID__',
+    id = generateRandomString(),
+}: PropsWithChildren<{prefixId?: string; id?: string}>) => {
+    let lastLocalId: number = 0
+
+    const getHookedId = (originalId?: string) => {
+        if (!originalId) {
+            return null
+        }
+        if (!localIdsMap.has(originalId)) {
+            localIdsMap.set(originalId, lastLocalId++)
+        }
+
+        const localId = localIdsMap.get(originalId)
+        return `${prefixId}${id}__${localId}__`
+    }
+
+    const fixPropWithUrl = (prop: string) => {
+        if (typeof prop !== 'string') {
+            return prop
+        }
+
+        const [, originalId] = prop.match(/^url\(#(.*)\)$/) || [null, null]
+
+        if (originalId === null) {
+            return prop
+        }
+
+        const fixedId = getHookedId(originalId)
+
+        if (fixedId === null) {
+            return prop
+        }
+
+        return `url(#${fixedId})`
+    }
+
+    const getHookedXlinkHref = (prop: string) => {
+        if (typeof prop !== 'string' || !prop.startsWith('#')) {
+            return prop
+        }
+
+        const originalId = prop.replace('#', '')
+
+        const fixedId = getHookedId(originalId)
+        if (fixedId === null) {
+            return prop
+        }
+
+        return `#${fixedId}`
+    }
+
+    return (
+        <>
+            {reactRecursiveChildrenMap(children, (child) => {
+                if (
+                    !child ||
+                    typeof child === 'string' ||
+                    typeof child === 'number' ||
+                    !('props' in (child as ReactElement))
+                ) {
+                    return null
+                }
+
+                const ch = child as ReactElement
+
+                const fixedId = getHookedId(ch.props.id)
+
+                const fixedProps = {
+                    ...ch.props,
+                }
+
+                Object.keys(fixedProps).map((key) => (fixedProps[key] = fixPropWithUrl(fixedProps[key])))
+                return cloneElement(ch, {
+                    ...fixedProps,
+                    id: fixedId,
+                    xlinkHref: getHookedXlinkHref(ch.props.xlinkHref),
+                })
+            })}
+        </>
+    )
+}
+
+export default SvgUniqueID

--- a/packages/svg-manager/src/index.ts
+++ b/packages/svg-manager/src/index.ts
@@ -1,0 +1,5 @@
+export {default as SvgUniqueID} from './SvgUniqueID'
+
+export {toSingleton} from './utils'
+
+export type {SVGStyleProps} from './types/svg'

--- a/packages/svg-manager/src/types/svg.ts
+++ b/packages/svg-manager/src/types/svg.ts
@@ -1,0 +1,24 @@
+import {SVGProps} from 'react'
+
+import {Property} from 'csstype'
+
+import {IntRange} from './utility-types'
+
+type FillName = `fill${IntRange<2, 6>}`
+
+type SVGFillProps = {
+    [key in FillName]?: Property.Fill
+}
+
+export interface SVGStyleProps extends SVGProps<SVGSVGElement>, SVGFillProps {
+    id?: string
+    fill?: Property.Fill
+    fill2?: Property.Fill
+    fill3?: Property.Fill
+    width?: Property.Width<string | number>
+    height?: Property.Height<string | number>
+    viewBox?: string
+    opacity?: Property.Opacity
+    style?: React.CSSProperties
+    stroke?: Property.Stroke
+}

--- a/packages/svg-manager/src/types/utility-types.ts
+++ b/packages/svg-manager/src/types/utility-types.ts
@@ -1,0 +1,13 @@
+/**
+ * @description 숫자 열거 타입
+ * @example Enumerate<2> // 0 | 1
+ */
+export type Enumerate<N extends number, Arr extends number[] = []> = Arr['length'] extends N
+    ? Arr[number]
+    : Enumerate<N, [...Arr, Arr['length']]>
+
+/**
+ * @description 범위 지정 타입
+ * @example IntRange<1, 100> // 1 | 2 | 3 | 4 | ... | 99
+ */
+export type IntRange<F extends number, T extends number> = Exclude<Enumerate<T>, Enumerate<F>>

--- a/packages/svg-manager/src/utils/deepMap.ts
+++ b/packages/svg-manager/src/utils/deepMap.ts
@@ -1,0 +1,38 @@
+import {Children, cloneElement, isValidElement} from 'react'
+
+import type {ReactElement, ReactNode} from 'react'
+
+function hasChildren(element: ReactNode): element is ReactElement<{children: ReactNode | ReactNode[]}> {
+    return isValidElement<{children?: ReactNode[]}>(element) && Boolean(element.props.children)
+}
+
+function hasComplexChildren(element: ReactNode): element is ReactElement<{children: ReactNode | ReactNode[]}> {
+    return (
+        isValidElement(element) &&
+        hasChildren(element) &&
+        Children.toArray(element.props.children).reduce(
+            (response: boolean, child: ReactNode): boolean => response || isValidElement(child),
+            false,
+        )
+    )
+}
+
+function deepMap(
+    children: ReactNode | ReactNode[],
+    deepMapFn: (child: ReactNode, index?: number, children?: ReactNode[]) => ReactNode,
+): ReactNode[] {
+    return Children.toArray(children).map((child: ReactNode, index: number, mapChildren: ReactNode[]) => {
+        if (isValidElement(child) && hasComplexChildren(child)) {
+            // Clone the child that has children and map them too
+            return deepMapFn(
+                cloneElement(child, {
+                    ...child.props,
+                    children: deepMap(child.props.children, deepMapFn),
+                }),
+            )
+        }
+        return deepMapFn(child, index, mapChildren)
+    })
+}
+
+export default deepMap

--- a/packages/svg-manager/src/utils/getSecureMathRandom.ts
+++ b/packages/svg-manager/src/utils/getSecureMathRandom.ts
@@ -1,0 +1,53 @@
+// TODO: common-utils 이관 필요
+declare global {
+    interface Window {
+        msCrypto: Crypto
+    }
+}
+
+function getSecureMathRandomBrowser() {
+    const array = new Uint32Array(1)
+    const maxNumber = Math.pow(2, 32) - 1
+
+    if (typeof window.msCrypto !== 'undefined') {
+        return window.msCrypto.getRandomValues(array)[0] / maxNumber
+    }
+
+    if (typeof window.crypto !== 'undefined') {
+        return window.crypto.getRandomValues(array)[0] / maxNumber
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(`fail to generate secure random. Neither window.msCrypto nor window.crypto is defined in window`)
+    return Math.random()
+}
+
+function getSecureMathRandomServer() {
+    const array = new Uint32Array(1)
+    const maxNumber = Math.pow(2, 32) - 1
+
+    if (!crypto || !crypto?.getRandomValues) {
+        // eslint-disable-next-line no-console
+        console.log(
+            "If the node version is less than 20, a require ('crypto') is required. To use the getSecureMathRandomServer properly, update the node version to 20 or higher.",
+        )
+        return Math.random()
+    }
+
+    return crypto.getRandomValues(array)[0] / maxNumber
+}
+
+export default function getSecureMathRandom() {
+    try {
+        if (typeof window === 'undefined') {
+            return getSecureMathRandomServer()
+        } else {
+            return getSecureMathRandomBrowser()
+        }
+    } catch (e) {
+        // eslint-disable-next-line no-console
+        console.log(`fail to generate secure random reason: ${e}`)
+    }
+
+    return Math.random()
+}

--- a/packages/svg-manager/src/utils/index.ts
+++ b/packages/svg-manager/src/utils/index.ts
@@ -1,0 +1,33 @@
+import getSecureMathRandom from './getSecureMathRandom'
+
+function createSingleton<T>(fn: () => T): () => T {
+    const memoize = () => {
+        const key = 'MEMOIZED_KEY'
+        const cache = memoize.cache
+
+        if (cache.has(key)) {
+            return cache.get(key)
+        }
+        const result = fn()
+
+        memoize.cache = cache.set(key, result) || cache
+
+        return result
+    }
+
+    memoize.cache = new Map()
+
+    return memoize
+}
+
+export function toSingleton<T>(fn: () => T): () => T {
+    return createSingleton<T>(fn)
+}
+
+export function generateRandomString<T>(...prefixes: T[]) {
+    const MAX_RADIX = 36
+    const DECIMAL_POINT_IDX = 2
+    const randomString = getSecureMathRandom().toString(MAX_RADIX).slice(DECIMAL_POINT_IDX)
+
+    return [...prefixes, randomString].join('_')
+}

--- a/packages/svg-manager/tsconfig.json
+++ b/packages/svg-manager/tsconfig.json
@@ -2,8 +2,9 @@
     "extends": "@naverpay/tsconfig/base.json",
     "compilerOptions": {
         "baseUrl": ".",
-        "outDir": "./dist",
-        "rootDir": "./src"
+        "outDir": "./dist/cjs",
+        "rootDir": "./src",
+        "emitDeclarationOnly": true
     },
     "include": ["./src", "./typings"],
     "exclude": ["node_modules", "dist"]

--- a/packages/svg-manager/tsconfig.json
+++ b/packages/svg-manager/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "@naverpay/tsconfig/base.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "outDir": "./dist",
+        "rootDir": "./src"
+    },
+    "include": ["./src", "./typings"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 2.27.1
       '@naverpay/eslint-config':
         specifier: ^0.2.0
-        version: 0.2.0(@babel/core@7.24.4)(@babel/eslint-parser@7.24.1)(@babel/plugin-proposal-class-properties@7.18.6)(@babel/plugin-transform-react-jsx@7.23.4)(@next/eslint-plugin-next@14.1.4)(@typescript-eslint/eslint-plugin@6.10.0)(@typescript-eslint/parser@6.21.0)(eslint-config-eslint@7.0.0)(eslint-config-prettier@9.1.0)(eslint-config-standard@17.1.0)(eslint-plugin-import@2.25.2)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-node@11.1.0)(eslint-plugin-promise@6.1.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.34.1)(eslint-plugin-unused-imports@3.1.0)(eslint@8.57.0)(prettier@2.8.8)
+        version: 0.2.0(@babel/core@7.24.4)(@babel/eslint-parser@7.24.1(@babel/core@7.24.4)(eslint@8.57.0))(@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.24.4))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.4))(@next/eslint-plugin-next@14.1.4)(@typescript-eslint/eslint-plugin@6.10.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3))(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-config-eslint@7.0.0(eslint-plugin-jsdoc@48.2.3(eslint@8.57.0))(eslint-plugin-node@11.1.0(eslint@8.57.0)))(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint-config-standard@17.1.0(eslint-plugin-import@2.25.2(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint-plugin-n@16.6.2(eslint@8.57.0))(eslint-plugin-promise@6.1.1(eslint@8.57.0))(eslint@8.57.0))(eslint-plugin-import@2.25.2(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint-plugin-jsx-a11y@6.8.0(eslint@8.57.0))(eslint-plugin-node@11.1.0(eslint@8.57.0))(eslint-plugin-promise@6.1.1(eslint@8.57.0))(eslint-plugin-react-hooks@4.6.0(eslint@8.57.0))(eslint-plugin-react@7.34.1(eslint@8.57.0))(eslint-plugin-unused-imports@3.1.0(@typescript-eslint/eslint-plugin@6.10.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0)(prettier@2.8.8)
       '@naverpay/markdown-lint':
         specifier: ^0.0.2
         version: 0.0.2
@@ -46,10 +46,10 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: 3.0.1
-        version: 3.0.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+        version: 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/preset-classic':
         specifier: 3.0.1
-        version: 3.0.1(@algolia/client-search@4.23.3)(@types/react@18.2.75)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.13.0)(typescript@5.3.3)
+        version: 3.0.1(@algolia/client-search@4.23.3)(@swc/core@1.4.15)(@types/react@18.2.75)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.13.0)(typescript@5.3.3)
       '@mdx-js/react':
         specifier: ^3.0.0
         version: 3.0.1(@types/react@18.2.75)(react@18.2.0)
@@ -70,20 +70,20 @@ importers:
         version: 7.6.0
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@20.12.7)(typescript@5.3.3)
+        version: 10.9.2(@swc/core@1.4.15)(@types/node@20.12.7)(typescript@5.3.3)
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: 3.0.1
-        version: 3.0.1(react-dom@18.2.0)(react@18.2.0)
+        version: 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/tsconfig':
         specifier: 3.0.1
         version: 3.0.1
       '@docusaurus/types':
         specifier: 3.0.1
-        version: 3.0.1(react-dom@18.2.0)(react@18.2.0)
+        version: 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@easyops-cn/docusaurus-search-local':
         specifier: ^0.40.1
-        version: 0.40.1(@docusaurus/theme-common@3.2.1)(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+        version: 0.40.1(@docusaurus/theme-common@3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3))(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@naverpay/browserslist-config':
         specifier: 1.6.1
         version: 1.6.1
@@ -98,7 +98,7 @@ importers:
     devDependencies:
       '@storybook/addon-essentials':
         specifier: ^7.6.10
-        version: 7.6.17(react-dom@18.2.0)(react@18.2.0)
+        version: 7.6.17(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/addon-interactions':
         specifier: ^7.6.10
         version: 7.6.17
@@ -107,22 +107,22 @@ importers:
         version: 7.6.17(react@18.2.0)
       '@storybook/addon-onboarding':
         specifier: ^1.0.10
-        version: 1.0.11(react-dom@18.2.0)(react@18.2.0)
+        version: 1.0.11(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/addon-styling-webpack':
         specifier: ^0.0.6
-        version: 0.0.6(webpack@5.90.3)
+        version: 0.0.6(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))
       '@storybook/blocks':
         specifier: ^7.6.10
-        version: 7.6.17(react-dom@18.2.0)(react@18.2.0)
+        version: 7.6.17(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/react-webpack5':
         specifier: ^7.6.10
-        version: 7.6.17(@babel/core@7.24.4)(@swc/core@1.4.15)(esbuild@0.18.20)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+        version: 7.6.17(@babel/core@7.24.4)(@swc/core@1.4.15)(esbuild@0.18.20)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@3.13.1)(typescript@5.3.3)(webpack-dev-server@4.15.2(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)))(webpack-hot-middleware@2.26.1)
       core-js:
         specifier: ^3.29.0
         version: 3.37.0
       css-loader:
         specifier: ^5.2.6
-        version: 5.2.7(webpack@5.90.3)
+        version: 5.2.7(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -134,7 +134,7 @@ importers:
         version: 1.75.0
       sass-loader:
         specifier: ^10.2.0
-        version: 10.5.2(sass@1.75.0)(webpack@5.90.3)
+        version: 10.5.2(sass@1.75.0)(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))
       storybook:
         specifier: ^7.6.10
         version: 7.6.17
@@ -143,7 +143,7 @@ importers:
         version: 1.0.3
       style-loader:
         specifier: ^2.0.0
-        version: 2.0.0(webpack@5.90.3)
+        version: 2.0.0(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))
       tsconfig-paths-webpack-plugin:
         specifier: ^3.5.1
         version: 3.5.2
@@ -231,7 +231,7 @@ importers:
         version: 8.4.38
       rollup-plugin-postcss:
         specifier: ^4.0.2
-        version: 4.0.2(postcss@8.4.38)
+        version: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3))
       rollup-plugin-preserve-directives:
         specifier: ^0.1.1
         version: 0.1.1(rollup@2.79.1)
@@ -254,6 +254,31 @@ importers:
       '@types/node':
         specifier: ^20.12.7
         version: 20.12.7
+      rollup:
+        specifier: ^2.79.1
+        version: 2.79.1
+
+  packages/svg-manager:
+    dependencies:
+      react:
+        specifier: ^17 || ^18
+        version: 18.2.0
+      react-dom:
+        specifier: ^17 || ^18
+        version: 18.2.0(react@18.2.0)
+    devDependencies:
+      '@naverpay/rollup':
+        specifier: workspace:^
+        version: link:../rollup
+      '@naverpay/tsconfig':
+        specifier: workspace:^
+        version: link:../tsconfig
+      '@types/react':
+        specifier: ^18.2.75
+        version: 18.2.75
+      csstype:
+        specifier: ^3.1.3
+        version: 3.1.3
       rollup:
         specifier: ^2.79.1
         version: 2.79.1
@@ -9992,20 +10017,21 @@ snapshots:
 
   '@docsearch/css@3.6.0': {}
 
-  '@docsearch/react@3.6.0(@algolia/client-search@4.23.3)(@types/react@18.2.75)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.13.0)':
+  '@docsearch/react@3.6.0(@algolia/client-search@4.23.3)(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.13.0)':
     dependencies:
       '@algolia/autocomplete-core': 1.9.3(@algolia/client-search@4.23.3)(algoliasearch@4.23.3)(search-insights@2.13.0)
       '@algolia/autocomplete-preset-algolia': 1.9.3(@algolia/client-search@4.23.3)(algoliasearch@4.23.3)
       '@docsearch/css': 3.6.0
-      '@types/react': 18.2.75
       algoliasearch: 4.23.3
+    optionalDependencies:
+      '@types/react': 18.2.75
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       search-insights: 2.13.0
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/core@3.0.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/core@3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
       '@babel/core': 7.24.4
       '@babel/generator': 7.24.4
@@ -10019,15 +10045,15 @@ snapshots:
       '@babel/traverse': 7.24.1
       '@docusaurus/cssnano-preset': 3.0.1
       '@docusaurus/logger': 3.0.1
-      '@docusaurus/mdx-loader': 3.0.1(@docusaurus/types@3.0.1)(react-dom@18.2.0)(react@18.2.0)
+      '@docusaurus/mdx-loader': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/react-loadable': 5.5.2(react@18.2.0)
-      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1)
-      '@docusaurus/utils-common': 3.0.1(@docusaurus/types@3.0.1)
-      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1)
+      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-common': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       '@slorber/static-site-generator-webpack-plugin': 4.0.7
       '@svgr/webpack': 6.5.1
       autoprefixer: 10.4.19(postcss@8.4.38)
-      babel-loader: 9.1.3(@babel/core@7.24.4)(webpack@5.90.3)
+      babel-loader: 9.1.3(@babel/core@7.24.4)(webpack@5.90.3(@swc/core@1.4.15))
       babel-plugin-dynamic-import-node: 2.3.3
       boxen: 6.2.1
       chalk: 4.1.2
@@ -10036,48 +10062,48 @@ snapshots:
       cli-table3: 0.6.4
       combine-promises: 1.2.0
       commander: 5.1.0
-      copy-webpack-plugin: 11.0.0(webpack@5.90.3)
+      copy-webpack-plugin: 11.0.0(webpack@5.90.3(@swc/core@1.4.15))
       core-js: 3.37.0
-      css-loader: 6.11.0(webpack@5.90.3)
-      css-minimizer-webpack-plugin: 4.2.2(clean-css@5.3.3)(webpack@5.90.3)
+      css-loader: 6.11.0(webpack@5.90.3(@swc/core@1.4.15))
+      css-minimizer-webpack-plugin: 4.2.2(clean-css@5.3.3)(webpack@5.90.3(@swc/core@1.4.15))
       cssnano: 5.1.15(postcss@8.4.38)
       del: 6.1.1
       detect-port: 1.5.1
       escape-html: 1.0.3
       eta: 2.2.0
-      file-loader: 6.2.0(webpack@5.90.3)
+      file-loader: 6.2.0(webpack@5.90.3(@swc/core@1.4.15))
       fs-extra: 11.2.0
       html-minifier-terser: 7.2.0
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.0(webpack@5.90.3)
+      html-webpack-plugin: 5.6.0(webpack@5.90.3(@swc/core@1.4.15))
       leven: 3.1.0
       lodash: 4.17.21
-      mini-css-extract-plugin: 2.9.0(webpack@5.90.3)
+      mini-css-extract-plugin: 2.9.0(webpack@5.90.3(@swc/core@1.4.15))
       postcss: 8.4.38
-      postcss-loader: 7.3.4(postcss@8.4.38)(typescript@5.3.3)(webpack@5.90.3)
+      postcss-loader: 7.3.4(postcss@8.4.38)(typescript@5.3.3)(webpack@5.90.3(@swc/core@1.4.15))
       prompts: 2.4.2
       react: 18.2.0
-      react-dev-utils: 12.0.1(eslint@8.57.0)(typescript@5.3.3)(webpack@5.90.3)
+      react-dev-utils: 12.0.1(eslint@8.57.0)(typescript@5.3.3)(webpack@5.90.3(@swc/core@1.4.15))
       react-dom: 18.2.0(react@18.2.0)
-      react-helmet-async: 1.3.0(react-dom@18.2.0)(react@18.2.0)
+      react-helmet-async: 1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-loadable: '@docusaurus/react-loadable@5.5.2(react@18.2.0)'
-      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@5.5.2)(webpack@5.90.3)
+      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@5.5.2(react@18.2.0))(webpack@5.90.3(@swc/core@1.4.15))
       react-router: 5.3.4(react@18.2.0)
-      react-router-config: 5.1.1(react-router@5.3.4)(react@18.2.0)
+      react-router-config: 5.1.1(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       react-router-dom: 5.3.4(react@18.2.0)
       rtl-detect: 1.1.2
       semver: 7.6.0
       serve-handler: 6.1.5
       shelljs: 0.8.5
-      terser-webpack-plugin: 5.3.10(webpack@5.90.3)
+      terser-webpack-plugin: 5.3.10(@swc/core@1.4.15)(webpack@5.90.3(@swc/core@1.4.15))
       tslib: 2.6.2
       update-notifier: 6.0.2
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.90.3)
-      webpack: 5.90.3
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.90.3(@swc/core@1.4.15)))(webpack@5.90.3(@swc/core@1.4.15))
+      webpack: 5.90.3(@swc/core@1.4.15)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 4.15.2(debug@4.3.4)(webpack@5.90.3)
+      webpack-dev-server: 4.15.2(webpack@5.90.3(@swc/core@1.4.15))
       webpack-merge: 5.10.0
-      webpackbar: 5.0.2(webpack@5.90.3)
+      webpackbar: 5.0.2(webpack@5.90.3(@swc/core@1.4.15))
     transitivePeerDependencies:
       - '@docusaurus/types'
       - '@parcel/css'
@@ -10097,7 +10123,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/core@3.2.1(@docusaurus/types@3.2.1)(debug@4.3.4)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/core@3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(debug@4.3.4)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
       '@babel/core': 7.24.4
       '@babel/generator': 7.24.4
@@ -10111,14 +10137,14 @@ snapshots:
       '@babel/traverse': 7.24.1
       '@docusaurus/cssnano-preset': 3.2.1
       '@docusaurus/logger': 3.2.1
-      '@docusaurus/mdx-loader': 3.2.1(@docusaurus/types@3.2.1)(react-dom@18.2.0)(react@18.2.0)
+      '@docusaurus/mdx-loader': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/react-loadable': 5.5.2(react@18.2.0)
-      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.2.1)
-      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.2.1)
-      '@docusaurus/utils-validation': 3.2.1(@docusaurus/types@3.2.1)
+      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       '@svgr/webpack': 6.5.1
       autoprefixer: 10.4.19(postcss@8.4.38)
-      babel-loader: 9.1.3(@babel/core@7.24.4)(webpack@5.90.3)
+      babel-loader: 9.1.3(@babel/core@7.24.4)(webpack@5.90.3(@swc/core@1.4.15))
       babel-plugin-dynamic-import-node: 2.3.3
       boxen: 6.2.1
       chalk: 4.1.2
@@ -10127,50 +10153,143 @@ snapshots:
       cli-table3: 0.6.4
       combine-promises: 1.2.0
       commander: 5.1.0
-      copy-webpack-plugin: 11.0.0(webpack@5.90.3)
+      copy-webpack-plugin: 11.0.0(webpack@5.90.3(@swc/core@1.4.15))
       core-js: 3.37.0
-      css-loader: 6.11.0(webpack@5.90.3)
-      css-minimizer-webpack-plugin: 4.2.2(clean-css@5.3.3)(webpack@5.90.3)
+      css-loader: 6.11.0(webpack@5.90.3(@swc/core@1.4.15))
+      css-minimizer-webpack-plugin: 4.2.2(clean-css@5.3.3)(webpack@5.90.3(@swc/core@1.4.15))
       cssnano: 5.1.15(postcss@8.4.38)
       del: 6.1.1
       detect-port: 1.5.1
       escape-html: 1.0.3
       eta: 2.2.0
       eval: 0.1.8
-      file-loader: 6.2.0(webpack@5.90.3)
+      file-loader: 6.2.0(webpack@5.90.3(@swc/core@1.4.15))
       fs-extra: 11.2.0
       html-minifier-terser: 7.2.0
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.0(webpack@5.90.3)
+      html-webpack-plugin: 5.6.0(webpack@5.90.3(@swc/core@1.4.15))
       leven: 3.1.0
       lodash: 4.17.21
-      mini-css-extract-plugin: 2.9.0(webpack@5.90.3)
+      mini-css-extract-plugin: 2.9.0(webpack@5.90.3(@swc/core@1.4.15))
       p-map: 4.0.0
       postcss: 8.4.38
-      postcss-loader: 7.3.4(postcss@8.4.38)(typescript@5.3.3)(webpack@5.90.3)
+      postcss-loader: 7.3.4(postcss@8.4.38)(typescript@5.3.3)(webpack@5.90.3(@swc/core@1.4.15))
       prompts: 2.4.2
       react: 18.2.0
-      react-dev-utils: 12.0.1(eslint@8.57.0)(typescript@5.3.3)(webpack@5.90.3)
+      react-dev-utils: 12.0.1(eslint@8.57.0)(typescript@5.3.3)(webpack@5.90.3(@swc/core@1.4.15))
       react-dom: 18.2.0(react@18.2.0)
-      react-helmet-async: 1.3.0(react-dom@18.2.0)(react@18.2.0)
+      react-helmet-async: 1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-loadable: '@docusaurus/react-loadable@5.5.2(react@18.2.0)'
-      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@5.5.2)(webpack@5.90.3)
+      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@5.5.2(react@18.2.0))(webpack@5.90.3(@swc/core@1.4.15))
       react-router: 5.3.4(react@18.2.0)
-      react-router-config: 5.1.1(react-router@5.3.4)(react@18.2.0)
+      react-router-config: 5.1.1(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       react-router-dom: 5.3.4(react@18.2.0)
       rtl-detect: 1.1.2
       semver: 7.6.0
       serve-handler: 6.1.5
       shelljs: 0.8.5
-      terser-webpack-plugin: 5.3.10(webpack@5.90.3)
+      terser-webpack-plugin: 5.3.10(@swc/core@1.4.15)(webpack@5.90.3(@swc/core@1.4.15))
       tslib: 2.6.2
       update-notifier: 6.0.2
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.90.3)
-      webpack: 5.90.3
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.90.3(@swc/core@1.4.15)))(webpack@5.90.3(@swc/core@1.4.15))
+      webpack: 5.90.3(@swc/core@1.4.15)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 4.15.2(debug@4.3.4)(webpack@5.90.3)
+      webpack-dev-server: 4.15.2(debug@4.3.4)(webpack@5.90.3(@swc/core@1.4.15))
       webpack-merge: 5.10.0
-      webpackbar: 5.0.2(webpack@5.90.3)
+      webpackbar: 5.0.2(webpack@5.90.3(@swc/core@1.4.15))
+    transitivePeerDependencies:
+      - '@docusaurus/types'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+
+  '@docusaurus/core@3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
+    dependencies:
+      '@babel/core': 7.24.4
+      '@babel/generator': 7.24.4
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.4)
+      '@babel/plugin-transform-runtime': 7.24.3(@babel/core@7.24.4)
+      '@babel/preset-env': 7.24.4(@babel/core@7.24.4)
+      '@babel/preset-react': 7.24.1(@babel/core@7.24.4)
+      '@babel/preset-typescript': 7.24.1(@babel/core@7.24.4)
+      '@babel/runtime': 7.23.9
+      '@babel/runtime-corejs3': 7.24.4
+      '@babel/traverse': 7.24.1
+      '@docusaurus/cssnano-preset': 3.2.1
+      '@docusaurus/logger': 3.2.1
+      '@docusaurus/mdx-loader': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/react-loadable': 5.5.2(react@18.2.0)
+      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@svgr/webpack': 6.5.1
+      autoprefixer: 10.4.19(postcss@8.4.38)
+      babel-loader: 9.1.3(@babel/core@7.24.4)(webpack@5.90.3(@swc/core@1.4.15))
+      babel-plugin-dynamic-import-node: 2.3.3
+      boxen: 6.2.1
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      clean-css: 5.3.3
+      cli-table3: 0.6.4
+      combine-promises: 1.2.0
+      commander: 5.1.0
+      copy-webpack-plugin: 11.0.0(webpack@5.90.3(@swc/core@1.4.15))
+      core-js: 3.37.0
+      css-loader: 6.11.0(webpack@5.90.3(@swc/core@1.4.15))
+      css-minimizer-webpack-plugin: 4.2.2(clean-css@5.3.3)(webpack@5.90.3(@swc/core@1.4.15))
+      cssnano: 5.1.15(postcss@8.4.38)
+      del: 6.1.1
+      detect-port: 1.5.1
+      escape-html: 1.0.3
+      eta: 2.2.0
+      eval: 0.1.8
+      file-loader: 6.2.0(webpack@5.90.3(@swc/core@1.4.15))
+      fs-extra: 11.2.0
+      html-minifier-terser: 7.2.0
+      html-tags: 3.3.1
+      html-webpack-plugin: 5.6.0(webpack@5.90.3(@swc/core@1.4.15))
+      leven: 3.1.0
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.9.0(webpack@5.90.3(@swc/core@1.4.15))
+      p-map: 4.0.0
+      postcss: 8.4.38
+      postcss-loader: 7.3.4(postcss@8.4.38)(typescript@5.3.3)(webpack@5.90.3(@swc/core@1.4.15))
+      prompts: 2.4.2
+      react: 18.2.0
+      react-dev-utils: 12.0.1(eslint@8.57.0)(typescript@5.3.3)(webpack@5.90.3(@swc/core@1.4.15))
+      react-dom: 18.2.0(react@18.2.0)
+      react-helmet-async: 1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-loadable: '@docusaurus/react-loadable@5.5.2(react@18.2.0)'
+      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@5.5.2(react@18.2.0))(webpack@5.90.3(@swc/core@1.4.15))
+      react-router: 5.3.4(react@18.2.0)
+      react-router-config: 5.1.1(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      react-router-dom: 5.3.4(react@18.2.0)
+      rtl-detect: 1.1.2
+      semver: 7.6.0
+      serve-handler: 6.1.5
+      shelljs: 0.8.5
+      terser-webpack-plugin: 5.3.10(@swc/core@1.4.15)(webpack@5.90.3(@swc/core@1.4.15))
+      tslib: 2.6.2
+      update-notifier: 6.0.2
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.90.3(@swc/core@1.4.15)))(webpack@5.90.3(@swc/core@1.4.15))
+      webpack: 5.90.3(@swc/core@1.4.15)
+      webpack-bundle-analyzer: 4.10.2
+      webpack-dev-server: 4.15.2(webpack@5.90.3(@swc/core@1.4.15))
+      webpack-merge: 5.10.0
+      webpackbar: 5.0.2(webpack@5.90.3(@swc/core@1.4.15))
     transitivePeerDependencies:
       - '@docusaurus/types'
       - '@parcel/css'
@@ -10214,18 +10333,18 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.6.2
 
-  '@docusaurus/mdx-loader@3.0.1(@docusaurus/types@3.0.1)(react-dom@18.2.0)(react@18.2.0)':
+  '@docusaurus/mdx-loader@3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/parser': 7.24.4
       '@babel/traverse': 7.24.1
       '@docusaurus/logger': 3.0.1
-      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1)
-      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1)
+      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       '@mdx-js/mdx': 3.0.1
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.1.1
-      file-loader: 6.2.0(webpack@5.90.3)
+      file-loader: 6.2.0(webpack@5.90.3(@swc/core@1.4.15))
       fs-extra: 11.2.0
       image-size: 1.1.1
       mdast-util-mdx: 3.0.0
@@ -10241,9 +10360,9 @@ snapshots:
       tslib: 2.6.2
       unified: 11.0.4
       unist-util-visit: 5.0.0
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.90.3)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.90.3(@swc/core@1.4.15)))(webpack@5.90.3(@swc/core@1.4.15))
       vfile: 6.0.1
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
     transitivePeerDependencies:
       - '@docusaurus/types'
       - '@swc/core'
@@ -10252,16 +10371,16 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/mdx-loader@3.2.1(@docusaurus/types@3.0.1)(react-dom@18.2.0)(react@18.2.0)':
+  '@docusaurus/mdx-loader@3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@docusaurus/logger': 3.2.1
-      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.0.1)
-      '@docusaurus/utils-validation': 3.2.1(@docusaurus/types@3.0.1)
+      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-validation': 3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       '@mdx-js/mdx': 3.0.1
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.1.1
-      file-loader: 6.2.0(webpack@5.90.3)
+      file-loader: 6.2.0(webpack@5.90.3(@swc/core@1.4.15))
       fs-extra: 11.2.0
       image-size: 1.1.1
       mdast-util-mdx: 3.0.0
@@ -10277,9 +10396,9 @@ snapshots:
       tslib: 2.6.2
       unified: 11.0.4
       unist-util-visit: 5.0.0
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.90.3)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.90.3(@swc/core@1.4.15)))(webpack@5.90.3(@swc/core@1.4.15))
       vfile: 6.0.1
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
     transitivePeerDependencies:
       - '@docusaurus/types'
       - '@swc/core'
@@ -10288,16 +10407,16 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/mdx-loader@3.2.1(@docusaurus/types@3.2.1)(react-dom@18.2.0)(react@18.2.0)':
+  '@docusaurus/mdx-loader@3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@docusaurus/logger': 3.2.1
-      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.2.1)
-      '@docusaurus/utils-validation': 3.2.1(@docusaurus/types@3.2.1)
+      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-validation': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       '@mdx-js/mdx': 3.0.1
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.1.1
-      file-loader: 6.2.0(webpack@5.90.3)
+      file-loader: 6.2.0(webpack@5.90.3(@swc/core@1.4.15))
       fs-extra: 11.2.0
       image-size: 1.1.1
       mdast-util-mdx: 3.0.0
@@ -10313,9 +10432,9 @@ snapshots:
       tslib: 2.6.2
       unified: 11.0.4
       unist-util-visit: 5.0.0
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.90.3)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.90.3(@swc/core@1.4.15)))(webpack@5.90.3(@swc/core@1.4.15))
       vfile: 6.0.1
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
     transitivePeerDependencies:
       - '@docusaurus/types'
       - '@swc/core'
@@ -10324,17 +10443,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.0.1(react-dom@18.2.0)(react@18.2.0)':
+  '@docusaurus/module-type-aliases@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@docusaurus/react-loadable': 5.5.2(react@18.2.0)
-      '@docusaurus/types': 3.0.1(react-dom@18.2.0)(react@18.2.0)
+      '@docusaurus/types': 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/history': 4.7.11
       '@types/react': 18.2.75
       '@types/react-router-config': 5.0.11
       '@types/react-router-dom': 5.3.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-helmet-async: 2.0.4(react-dom@18.2.0)(react@18.2.0)
+      react-helmet-async: 2.0.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-loadable: '@docusaurus/react-loadable@5.5.2(react@18.2.0)'
     transitivePeerDependencies:
       - '@swc/core'
@@ -10342,17 +10461,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.2.1(react-dom@18.2.0)(react@18.2.0)':
+  '@docusaurus/module-type-aliases@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@docusaurus/react-loadable': 5.5.2(react@18.2.0)
-      '@docusaurus/types': 3.2.1(react-dom@18.2.0)(react@18.2.0)
+      '@docusaurus/types': 3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/history': 4.7.11
       '@types/react': 18.2.75
       '@types/react-router-config': 5.0.11
       '@types/react-router-dom': 5.3.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-helmet-async: 2.0.4(react-dom@18.2.0)(react@18.2.0)
+      react-helmet-async: 2.0.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-loadable: '@docusaurus/react-loadable@5.5.2(react@18.2.0)'
     transitivePeerDependencies:
       - '@swc/core'
@@ -10361,15 +10480,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-content-blog@3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/logger': 3.0.1
-      '@docusaurus/mdx-loader': 3.0.1(@docusaurus/types@3.0.1)(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/types': 3.0.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1)
-      '@docusaurus/utils-common': 3.0.1(@docusaurus/types@3.0.1)
-      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1)
+      '@docusaurus/mdx-loader': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-common': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.2.0
@@ -10381,7 +10500,7 @@ snapshots:
       tslib: 2.6.2
       unist-util-visit: 5.0.0
       utility-types: 3.11.0
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -10400,15 +10519,15 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.2.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-content-blog@3.2.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.2.1(@docusaurus/types@3.2.1)(debug@4.3.4)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/core': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/logger': 3.2.1
-      '@docusaurus/mdx-loader': 3.2.1(@docusaurus/types@3.2.1)(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/types': 3.2.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.2.1)
-      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.2.1)
-      '@docusaurus/utils-validation': 3.2.1(@docusaurus/types@3.2.1)
+      '@docusaurus/mdx-loader': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.2.0
@@ -10420,7 +10539,7 @@ snapshots:
       tslib: 2.6.2
       unist-util-visit: 5.0.0
       utility-types: 3.11.0
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -10439,15 +10558,15 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-content-docs@3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/logger': 3.0.1
-      '@docusaurus/mdx-loader': 3.0.1(@docusaurus/types@3.0.1)(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/module-type-aliases': 3.0.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/types': 3.0.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1)
-      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1)
+      '@docusaurus/mdx-loader': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/module-type-aliases': 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.2.0
@@ -10457,7 +10576,7 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.6.2
       utility-types: 3.11.0
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -10476,16 +10595,16 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.2.1(debug@4.3.4)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-content-docs@3.2.1(@swc/core@1.4.15)(debug@4.3.4)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.2.1(@docusaurus/types@3.2.1)(debug@4.3.4)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/core': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(debug@4.3.4)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/logger': 3.2.1
-      '@docusaurus/mdx-loader': 3.2.1(@docusaurus/types@3.2.1)(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/module-type-aliases': 3.2.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/types': 3.2.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.2.1)
-      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.2.1)
-      '@docusaurus/utils-validation': 3.2.1(@docusaurus/types@3.2.1)
+      '@docusaurus/mdx-loader': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/module-type-aliases': 3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.2.0
@@ -10495,7 +10614,7 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.6.2
       utility-types: 3.11.0
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -10514,18 +10633,56 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-content-docs@3.2.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/mdx-loader': 3.0.1(@docusaurus/types@3.0.1)(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/types': 3.0.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1)
-      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1)
+      '@docusaurus/core': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/logger': 3.2.1
+      '@docusaurus/mdx-loader': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/module-type-aliases': 3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@types/react-router-config': 5.0.11
+      combine-promises: 1.2.0
+      fs-extra: 11.2.0
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      tslib: 2.6.2
+      utility-types: 3.11.0
+      webpack: 5.90.3(@swc/core@1.4.15)
+    transitivePeerDependencies:
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+
+  '@docusaurus/plugin-content-pages@3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
+    dependencies:
+      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/mdx-loader': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       fs-extra: 11.2.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.6.2
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -10544,18 +10701,18 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.2.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-content-pages@3.2.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.2.1(@docusaurus/types@3.2.1)(debug@4.3.4)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/mdx-loader': 3.2.1(@docusaurus/types@3.2.1)(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/types': 3.2.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.2.1)
-      '@docusaurus/utils-validation': 3.2.1(@docusaurus/types@3.2.1)
+      '@docusaurus/core': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/mdx-loader': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-validation': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       fs-extra: 11.2.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.6.2
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -10574,11 +10731,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-debug@3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/types': 3.0.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1)
+      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/types': 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       fs-extra: 11.2.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -10602,11 +10759,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-google-analytics@3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/types': 3.0.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1)
+      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/types': 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.6.2
@@ -10628,11 +10785,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-google-gtag@3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/types': 3.0.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1)
+      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/types': 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       '@types/gtag.js': 0.0.12
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -10655,11 +10812,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-google-tag-manager@3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/types': 3.0.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1)
+      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/types': 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.6.2
@@ -10681,14 +10838,14 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-sitemap@3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/logger': 3.0.1
-      '@docusaurus/types': 3.0.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1)
-      '@docusaurus/utils-common': 3.0.1(@docusaurus/types@3.0.1)
-      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1)
+      '@docusaurus/types': 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-common': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       fs-extra: 11.2.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -10712,21 +10869,21 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.0.1(@algolia/client-search@4.23.3)(@types/react@18.2.75)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.13.0)(typescript@5.3.3)':
+  '@docusaurus/preset-classic@3.0.1(@algolia/client-search@4.23.3)(@swc/core@1.4.15)(@types/react@18.2.75)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.13.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-content-blog': 3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-content-docs': 3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-content-pages': 3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-debug': 3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-google-analytics': 3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-google-gtag': 3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-google-tag-manager': 3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-sitemap': 3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/theme-classic': 3.0.1(@types/react@18.2.75)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/theme-common': 3.0.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/theme-search-algolia': 3.0.1(@algolia/client-search@4.23.3)(@docusaurus/types@3.0.1)(@types/react@18.2.75)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.13.0)(typescript@5.3.3)
-      '@docusaurus/types': 3.0.1(react-dom@18.2.0)(react@18.2.0)
+      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-blog': 3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-docs': 3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-pages': 3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-debug': 3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-google-analytics': 3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-google-gtag': 3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-google-tag-manager': 3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-sitemap': 3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/theme-classic': 3.0.1(@swc/core@1.4.15)(@types/react@18.2.75)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/theme-common': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/theme-search-algolia': 3.0.1(@algolia/client-search@4.23.3)(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(@types/react@18.2.75)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.13.0)(typescript@5.3.3)
+      '@docusaurus/types': 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -10756,20 +10913,20 @@ snapshots:
       prop-types: 15.8.1
       react: 18.2.0
 
-  '@docusaurus/theme-classic@3.0.1(@types/react@18.2.75)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/theme-classic@3.0.1(@swc/core@1.4.15)(@types/react@18.2.75)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/mdx-loader': 3.0.1(@docusaurus/types@3.0.1)(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/module-type-aliases': 3.0.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/plugin-content-blog': 3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-content-docs': 3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-content-pages': 3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/theme-common': 3.0.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/mdx-loader': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/module-type-aliases': 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/plugin-content-blog': 3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-docs': 3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-pages': 3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/theme-common': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/theme-translations': 3.0.1
-      '@docusaurus/types': 3.0.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1)
-      '@docusaurus/utils-common': 3.0.1(@docusaurus/types@3.0.1)
-      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1)
+      '@docusaurus/types': 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-common': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       '@mdx-js/react': 3.0.1(@types/react@18.2.75)(react@18.2.0)
       clsx: 2.1.0
       copy-text-to-clipboard: 3.2.0
@@ -10804,15 +10961,15 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.0.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/theme-common@3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.0.1(@docusaurus/types@3.0.1)(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/module-type-aliases': 3.0.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/plugin-content-blog': 3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-content-docs': 3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-content-pages': 3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1)
-      '@docusaurus/utils-common': 3.0.1(@docusaurus/types@3.0.1)
+      '@docusaurus/mdx-loader': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/module-type-aliases': 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/plugin-content-blog': 3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-docs': 3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-pages': 3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-common': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@types/history': 4.7.11
       '@types/react': 18.2.75
       '@types/react-router-config': 5.0.11
@@ -10842,15 +10999,15 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.2.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/theme-common@3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.2.1(@docusaurus/types@3.0.1)(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/module-type-aliases': 3.2.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/plugin-content-blog': 3.2.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-content-docs': 3.2.1(debug@4.3.4)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-content-pages': 3.2.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.0.1)
-      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.0.1)
+      '@docusaurus/mdx-loader': 3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/module-type-aliases': 3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/plugin-content-blog': 3.2.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-docs': 3.2.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-pages': 3.2.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@types/history': 4.7.11
       '@types/react': 18.2.75
       '@types/react-router-config': 5.0.11
@@ -10880,16 +11037,16 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.0.1(@algolia/client-search@4.23.3)(@docusaurus/types@3.0.1)(@types/react@18.2.75)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.13.0)(typescript@5.3.3)':
+  '@docusaurus/theme-search-algolia@3.0.1(@algolia/client-search@4.23.3)(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(@types/react@18.2.75)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.13.0)(typescript@5.3.3)':
     dependencies:
-      '@docsearch/react': 3.6.0(@algolia/client-search@4.23.3)(@types/react@18.2.75)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.13.0)
-      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@docsearch/react': 3.6.0(@algolia/client-search@4.23.3)(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.13.0)
+      '@docusaurus/core': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/logger': 3.0.1
-      '@docusaurus/plugin-content-docs': 3.0.1(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/theme-common': 3.0.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-docs': 3.0.1(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/theme-common': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/theme-translations': 3.0.1
-      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1)
-      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1)
+      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-validation': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       algoliasearch: 4.23.3
       algoliasearch-helper: 3.17.0(algoliasearch@4.23.3)
       clsx: 2.1.0
@@ -10934,7 +11091,7 @@ snapshots:
 
   '@docusaurus/tsconfig@3.0.1': {}
 
-  '@docusaurus/types@3.0.1(react-dom@18.2.0)(react@18.2.0)':
+  '@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@types/history': 4.7.11
       '@types/react': 18.2.75
@@ -10942,9 +11099,9 @@ snapshots:
       joi: 17.12.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-helmet-async: 1.3.0(react-dom@18.2.0)(react@18.2.0)
+      react-helmet-async: 1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       utility-types: 3.11.0
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -10952,7 +11109,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/types@3.2.1(react-dom@18.2.0)(react@18.2.0)':
+  '@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@mdx-js/mdx': 3.0.1
       '@types/history': 4.7.11
@@ -10961,9 +11118,9 @@ snapshots:
       joi: 17.12.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-helmet-async: 1.3.0(react-dom@18.2.0)(react@18.2.0)
+      react-helmet-async: 1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       utility-types: 3.11.0
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -10972,25 +11129,28 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.0.1(@docusaurus/types@3.0.1)':
+  '@docusaurus/utils-common@3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
-      '@docusaurus/types': 3.0.1(react-dom@18.2.0)(react@18.2.0)
       tslib: 2.6.2
+    optionalDependencies:
+      '@docusaurus/types': 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  '@docusaurus/utils-common@3.2.1(@docusaurus/types@3.0.1)':
+  '@docusaurus/utils-common@3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
-      '@docusaurus/types': 3.0.1(react-dom@18.2.0)(react@18.2.0)
       tslib: 2.6.2
+    optionalDependencies:
+      '@docusaurus/types': 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  '@docusaurus/utils-common@3.2.1(@docusaurus/types@3.2.1)':
+  '@docusaurus/utils-common@3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
-      '@docusaurus/types': 3.2.1(react-dom@18.2.0)(react@18.2.0)
       tslib: 2.6.2
+    optionalDependencies:
+      '@docusaurus/types': 3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  '@docusaurus/utils-validation@3.0.1(@docusaurus/types@3.0.1)':
+  '@docusaurus/utils-validation@3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)':
     dependencies:
       '@docusaurus/logger': 3.0.1
-      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1)
+      '@docusaurus/utils': 3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       joi: 17.12.3
       js-yaml: 4.1.0
       tslib: 2.6.2
@@ -11002,11 +11162,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-validation@3.2.1(@docusaurus/types@3.0.1)':
+  '@docusaurus/utils-validation@3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)':
     dependencies:
       '@docusaurus/logger': 3.2.1
-      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.0.1)
-      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.0.1)
+      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       joi: 17.12.3
       js-yaml: 4.1.0
       tslib: 2.6.2
@@ -11018,11 +11178,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-validation@3.2.1(@docusaurus/types@3.2.1)':
+  '@docusaurus/utils-validation@3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)':
     dependencies:
       '@docusaurus/logger': 3.2.1
-      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.2.1)
-      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.2.1)
+      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       joi: 17.12.3
       js-yaml: 4.1.0
       tslib: 2.6.2
@@ -11034,13 +11194,12 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.0.1(@docusaurus/types@3.0.1)':
+  '@docusaurus/utils@3.0.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)':
     dependencies:
       '@docusaurus/logger': 3.0.1
-      '@docusaurus/types': 3.0.1(react-dom@18.2.0)(react@18.2.0)
       '@svgr/webpack': 6.5.1
       escape-string-regexp: 4.0.0
-      file-loader: 6.2.0(webpack@5.90.3)
+      file-loader: 6.2.0(webpack@5.90.3(@swc/core@1.4.15))
       fs-extra: 11.2.0
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -11052,8 +11211,10 @@ snapshots:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.6.2
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.90.3)
-      webpack: 5.90.3
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.90.3(@swc/core@1.4.15)))(webpack@5.90.3(@swc/core@1.4.15))
+      webpack: 5.90.3(@swc/core@1.4.15)
+    optionalDependencies:
+      '@docusaurus/types': 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -11061,14 +11222,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.2.1(@docusaurus/types@3.0.1)':
+  '@docusaurus/utils@3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)':
     dependencies:
       '@docusaurus/logger': 3.2.1
-      '@docusaurus/types': 3.0.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.0.1)
+      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@svgr/webpack': 6.5.1
       escape-string-regexp: 4.0.0
-      file-loader: 6.2.0(webpack@5.90.3)
+      file-loader: 6.2.0(webpack@5.90.3(@swc/core@1.4.15))
       fs-extra: 11.2.0
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -11081,8 +11241,10 @@ snapshots:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.6.2
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.90.3)
-      webpack: 5.90.3
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.90.3(@swc/core@1.4.15)))(webpack@5.90.3(@swc/core@1.4.15))
+      webpack: 5.90.3(@swc/core@1.4.15)
+    optionalDependencies:
+      '@docusaurus/types': 3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -11090,14 +11252,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.2.1(@docusaurus/types@3.2.1)':
+  '@docusaurus/utils@3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)':
     dependencies:
       '@docusaurus/logger': 3.2.1
-      '@docusaurus/types': 3.2.1(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.2.1)
+      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@svgr/webpack': 6.5.1
       escape-string-regexp: 4.0.0
-      file-loader: 6.2.0(webpack@5.90.3)
+      file-loader: 6.2.0(webpack@5.90.3(@swc/core@1.4.15))
       fs-extra: 11.2.0
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -11110,8 +11271,10 @@ snapshots:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.6.2
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.90.3)
-      webpack: 5.90.3
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.90.3(@swc/core@1.4.15)))(webpack@5.90.3(@swc/core@1.4.15))
+      webpack: 5.90.3(@swc/core@1.4.15)
+    optionalDependencies:
+      '@docusaurus/types': 3.2.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -11124,14 +11287,14 @@ snapshots:
       cssesc: 3.0.0
       immediate: 3.3.0
 
-  '@easyops-cn/docusaurus-search-local@0.40.1(@docusaurus/theme-common@3.2.1)(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@easyops-cn/docusaurus-search-local@0.40.1(@docusaurus/theme-common@3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3))(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/plugin-content-docs': 3.2.1(debug@4.3.4)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/theme-common': 3.2.1(@docusaurus/types@3.0.1)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-docs': 3.2.1(@swc/core@1.4.15)(debug@4.3.4)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/theme-common': 3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/theme-translations': 3.2.1
-      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.0.1)
-      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.0.1)
-      '@docusaurus/utils-validation': 3.2.1(@docusaurus/types@3.0.1)
+      '@docusaurus/utils': 3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
+      '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.2.1(@docusaurus/types@3.0.1(@swc/core@1.4.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@swc/core@1.4.15)
       '@easyops-cn/autocomplete.js': 0.38.1
       '@node-rs/jieba': 1.10.0
       cheerio: 1.0.0-rc.12
@@ -11283,7 +11446,7 @@ snapshots:
       '@floating-ui/core': 1.6.0
       '@floating-ui/utils': 0.2.1
 
-  '@floating-ui/react-dom@2.0.8(react-dom@18.2.0)(react@18.2.0)':
+  '@floating-ui/react-dom@2.0.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@floating-ui/dom': 1.6.3
       react: 18.2.0
@@ -11465,26 +11628,26 @@ snapshots:
 
   '@naverpay/browserslist-config@1.6.1': {}
 
-  '@naverpay/eslint-config@0.2.0(@babel/core@7.24.4)(@babel/eslint-parser@7.24.1)(@babel/plugin-proposal-class-properties@7.18.6)(@babel/plugin-transform-react-jsx@7.23.4)(@next/eslint-plugin-next@14.1.4)(@typescript-eslint/eslint-plugin@6.10.0)(@typescript-eslint/parser@6.21.0)(eslint-config-eslint@7.0.0)(eslint-config-prettier@9.1.0)(eslint-config-standard@17.1.0)(eslint-plugin-import@2.25.2)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-node@11.1.0)(eslint-plugin-promise@6.1.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.34.1)(eslint-plugin-unused-imports@3.1.0)(eslint@8.57.0)(prettier@2.8.8)':
-    dependencies:
+  ? '@naverpay/eslint-config@0.2.0(@babel/core@7.24.4)(@babel/eslint-parser@7.24.1(@babel/core@7.24.4)(eslint@8.57.0))(@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.24.4))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.4))(@next/eslint-plugin-next@14.1.4)(@typescript-eslint/eslint-plugin@6.10.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3))(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-config-eslint@7.0.0(eslint-plugin-jsdoc@48.2.3(eslint@8.57.0))(eslint-plugin-node@11.1.0(eslint@8.57.0)))(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint-config-standard@17.1.0(eslint-plugin-import@2.25.2(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint-plugin-n@16.6.2(eslint@8.57.0))(eslint-plugin-promise@6.1.1(eslint@8.57.0))(eslint@8.57.0))(eslint-plugin-import@2.25.2(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint-plugin-jsx-a11y@6.8.0(eslint@8.57.0))(eslint-plugin-node@11.1.0(eslint@8.57.0))(eslint-plugin-promise@6.1.1(eslint@8.57.0))(eslint-plugin-react-hooks@4.6.0(eslint@8.57.0))(eslint-plugin-react@7.34.1(eslint@8.57.0))(eslint-plugin-unused-imports@3.1.0(@typescript-eslint/eslint-plugin@6.10.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0)(prettier@2.8.8)'
+  : dependencies:
       '@babel/core': 7.24.4
       '@babel/eslint-parser': 7.24.1(@babel/core@7.24.4)(eslint@8.57.0)
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.24.4)
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.24.4)
       '@next/eslint-plugin-next': 14.1.4
-      '@typescript-eslint/eslint-plugin': 6.10.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/eslint-plugin': 6.10.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
       eslint: 8.57.0
-      eslint-config-eslint: 7.0.0(eslint-plugin-jsdoc@48.2.3)(eslint-plugin-node@11.1.0)
+      eslint-config-eslint: 7.0.0(eslint-plugin-jsdoc@48.2.3(eslint@8.57.0))(eslint-plugin-node@11.1.0(eslint@8.57.0))
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.25.2)(eslint-plugin-n@16.6.2)(eslint-plugin-promise@6.1.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.25.2(@typescript-eslint/parser@6.21.0)(eslint@8.57.0)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.25.2(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint-plugin-n@16.6.2(eslint@8.57.0))(eslint-plugin-promise@6.1.1(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.25.2(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-node: 11.1.0(eslint@8.57.0)
       eslint-plugin-promise: 6.1.1(eslint@8.57.0)
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
-      eslint-plugin-unused-imports: 3.1.0(@typescript-eslint/eslint-plugin@6.10.0)(eslint@8.57.0)
+      eslint-plugin-unused-imports: 3.1.0(@typescript-eslint/eslint-plugin@6.10.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)
       prettier: 2.8.8
 
   '@naverpay/markdown-lint@0.0.2':
@@ -11586,7 +11749,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(react-refresh@0.14.0)(webpack@5.90.3)':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(react-refresh@0.14.0)(type-fest@3.13.1)(webpack-dev-server@4.15.2(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)))(webpack-hot-middleware@2.26.1)(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))':
     dependencies:
       ansi-html-community: 0.0.8
       common-path-prefix: 3.0.0
@@ -11599,6 +11762,10 @@ snapshots:
       schema-utils: 3.3.0
       source-map: 0.7.4
       webpack: 5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)
+    optionalDependencies:
+      type-fest: 3.13.1
+      webpack-dev-server: 4.15.2(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))
+      webpack-hot-middleware: 2.26.1
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -11635,234 +11802,288 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.23.9
 
-  '@radix-ui/react-arrow@1.0.3(react-dom@18.2.0)(react@18.2.0)':
+  '@radix-ui/react-arrow@1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-collection@1.0.3(react-dom@18.2.0)(react@18.2.0)':
+  '@radix-ui/react-collection@1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-compose-refs': 1.0.1(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-slot': 1.0.2(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.75)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-compose-refs@1.0.1(react@18.2.0)':
+  '@radix-ui/react-compose-refs@1.0.1(@types/react@18.2.75)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-context@1.0.1(react@18.2.0)':
+  '@radix-ui/react-context@1.0.1(@types/react@18.2.75)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-direction@1.0.1(react@18.2.0)':
+  '@radix-ui/react-direction@1.0.1(@types/react@18.2.75)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-dismissable-layer@1.0.4(react-dom@18.2.0)(react@18.2.0)':
+  '@radix-ui/react-dismissable-layer@1.0.4(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-compose-refs': 1.0.1(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(react@18.2.0)
-      '@radix-ui/react-use-escape-keydown': 1.0.3(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@18.2.75)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-focus-guards@1.0.1(react@18.2.0)':
+  '@radix-ui/react-focus-guards@1.0.1(@types/react@18.2.75)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-focus-scope@1.0.3(react-dom@18.2.0)(react@18.2.0)':
+  '@radix-ui/react-focus-scope@1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-compose-refs': 1.0.1(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.75)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-id@1.0.1(react@18.2.0)':
+  '@radix-ui/react-id@1.0.1(@types/react@18.2.75)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-use-layout-effect': 1.0.1(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.75)(react@18.2.0)
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-popper@1.1.2(react-dom@18.2.0)(react@18.2.0)':
+  '@radix-ui/react-popper@1.1.2(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@floating-ui/react-dom': 2.0.8(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-arrow': 1.0.3(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-compose-refs': 1.0.1(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.0.1(react@18.2.0)
-      '@radix-ui/react-use-rect': 1.0.1(react@18.2.0)
-      '@radix-ui/react-use-size': 1.0.1(react@18.2.0)
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-arrow': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-use-rect': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@18.2.75)(react@18.2.0)
       '@radix-ui/rect': 1.0.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-portal@1.0.3(react-dom@18.2.0)(react@18.2.0)':
+  '@radix-ui/react-portal@1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-primitive@1.0.3(react-dom@18.2.0)(react@18.2.0)':
+  '@radix-ui/react-primitive@1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-slot': 1.0.2(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.75)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-roving-focus@1.0.4(react-dom@18.2.0)(react@18.2.0)':
+  '@radix-ui/react-roving-focus@1.0.4(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-collection': 1.0.3(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-compose-refs': 1.0.1(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(react@18.2.0)
-      '@radix-ui/react-direction': 1.0.1(react@18.2.0)
-      '@radix-ui/react-id': 1.0.1(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(react@18.2.0)
+      '@radix-ui/react-collection': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.75)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-select@1.2.2(react-dom@18.2.0)(react@18.2.0)':
+  '@radix-ui/react-select@1.2.2(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/number': 1.0.1
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-collection': 1.0.3(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-compose-refs': 1.0.1(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(react@18.2.0)
-      '@radix-ui/react-direction': 1.0.1(react@18.2.0)
-      '@radix-ui/react-dismissable-layer': 1.0.4(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-focus-guards': 1.0.1(react@18.2.0)
-      '@radix-ui/react-focus-scope': 1.0.3(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-id': 1.0.1(react@18.2.0)
-      '@radix-ui/react-popper': 1.1.2(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-portal': 1.0.3(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-slot': 1.0.2(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.0.1(react@18.2.0)
-      '@radix-ui/react-use-previous': 1.0.1(react@18.2.0)
-      '@radix-ui/react-visually-hidden': 1.0.3(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-collection': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.0.4(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-popper': 1.1.2(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-portal': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-use-previous': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-visually-hidden': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       aria-hidden: 1.2.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-remove-scroll: 2.5.5(react@18.2.0)
+      react-remove-scroll: 2.5.5(@types/react@18.2.75)(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-separator@1.0.3(react-dom@18.2.0)(react@18.2.0)':
+  '@radix-ui/react-separator@1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-slot@1.0.2(react@18.2.0)':
+  '@radix-ui/react-slot@1.0.2(@types/react@18.2.75)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-compose-refs': 1.0.1(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.75)(react@18.2.0)
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-toggle-group@1.0.4(react-dom@18.2.0)(react@18.2.0)':
+  '@radix-ui/react-toggle-group@1.0.4(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-context': 1.0.1(react@18.2.0)
-      '@radix-ui/react-direction': 1.0.1(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-roving-focus': 1.0.4(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-toggle': 1.0.3(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-roving-focus': 1.0.4(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-toggle': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.75)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-toggle@1.0.3(react-dom@18.2.0)(react@18.2.0)':
+  '@radix-ui/react-toggle@1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.75)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-toolbar@1.0.4(react-dom@18.2.0)(react@18.2.0)':
+  '@radix-ui/react-toolbar@1.0.4(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-context': 1.0.1(react@18.2.0)
-      '@radix-ui/react-direction': 1.0.1(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-roving-focus': 1.0.4(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-separator': 1.0.3(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-toggle-group': 1.0.4(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.75)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-roving-focus': 1.0.4(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-separator': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-toggle-group': 1.0.4(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-use-callback-ref@1.0.1(react@18.2.0)':
+  '@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.2.75)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-use-controllable-state@1.0.1(react@18.2.0)':
+  '@radix-ui/react-use-controllable-state@1.0.1(@types/react@18.2.75)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-use-callback-ref': 1.0.1(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.75)(react@18.2.0)
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-use-escape-keydown@1.0.3(react@18.2.0)':
+  '@radix-ui/react-use-escape-keydown@1.0.3(@types/react@18.2.75)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-use-callback-ref': 1.0.1(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.75)(react@18.2.0)
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-use-layout-effect@1.0.1(react@18.2.0)':
+  '@radix-ui/react-use-layout-effect@1.0.1(@types/react@18.2.75)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-use-previous@1.0.1(react@18.2.0)':
+  '@radix-ui/react-use-previous@1.0.1(@types/react@18.2.75)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-use-rect@1.0.1(react@18.2.0)':
+  '@radix-ui/react-use-rect@1.0.1(@types/react@18.2.75)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/rect': 1.0.1
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-use-size@1.0.1(react@18.2.0)':
+  '@radix-ui/react-use-size@1.0.1(@types/react@18.2.75)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-use-layout-effect': 1.0.1(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.75)(react@18.2.0)
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  '@radix-ui/react-visually-hidden@1.0.3(react-dom@18.2.0)(react@18.2.0)':
+  '@radix-ui/react-visually-hidden@1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-primitive': 1.0.3(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.75
 
   '@radix-ui/rect@1.0.1':
     dependencies:
@@ -11873,8 +12094,9 @@ snapshots:
       '@babel/core': 7.24.4
       '@babel/helper-module-imports': 7.24.3
       '@rollup/pluginutils': 3.1.0(rollup@2.79.1)
-      '@types/babel__core': 7.20.5
       rollup: 2.79.1
+    optionalDependencies:
+      '@types/babel__core': 7.20.5
 
   '@rollup/plugin-commonjs@22.0.2(rollup@2.79.1)':
     dependencies:
@@ -11910,10 +12132,11 @@ snapshots:
 
   '@rollup/plugin-terser@0.4.4(rollup@2.79.1)':
     dependencies:
-      rollup: 2.79.1
       serialize-javascript: 6.0.2
       smob: 1.5.0
       terser: 5.28.1
+    optionalDependencies:
+      rollup: 2.79.1
 
   '@rollup/plugin-virtual@2.1.0(rollup@2.79.1)':
     dependencies:
@@ -12023,9 +12246,9 @@ snapshots:
       memoizerific: 1.11.3
       ts-dedent: 2.2.0
 
-  '@storybook/addon-controls@7.6.17(react-dom@18.2.0)(react@18.2.0)':
+  '@storybook/addon-controls@7.6.17(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@storybook/blocks': 7.6.17(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/blocks': 7.6.17(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       lodash: 4.17.21
       ts-dedent: 2.2.0
     transitivePeerDependencies:
@@ -12036,13 +12259,13 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@storybook/addon-docs@7.6.17(react-dom@18.2.0)(react@18.2.0)':
+  '@storybook/addon-docs@7.6.17(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@jest/transform': 29.7.0
       '@mdx-js/react': 2.3.0(react@18.2.0)
-      '@storybook/blocks': 7.6.17(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/blocks': 7.6.17(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/client-logger': 7.6.17
-      '@storybook/components': 7.6.17(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/components': 7.6.17(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/csf-plugin': 7.6.17
       '@storybook/csf-tools': 7.6.17
       '@storybook/global': 5.0.0
@@ -12050,8 +12273,8 @@ snapshots:
       '@storybook/node-logger': 7.6.17
       '@storybook/postinstall': 7.6.17
       '@storybook/preview-api': 7.6.17
-      '@storybook/react-dom-shim': 7.6.17(react-dom@18.2.0)(react@18.2.0)
-      '@storybook/theming': 7.6.17(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/react-dom-shim': 7.6.17(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@storybook/theming': 7.6.17(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/types': 7.6.17
       fs-extra: 11.2.0
       react: 18.2.0
@@ -12065,19 +12288,19 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/addon-essentials@7.6.17(react-dom@18.2.0)(react@18.2.0)':
+  '@storybook/addon-essentials@7.6.17(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@storybook/addon-actions': 7.6.17
       '@storybook/addon-backgrounds': 7.6.17
-      '@storybook/addon-controls': 7.6.17(react-dom@18.2.0)(react@18.2.0)
-      '@storybook/addon-docs': 7.6.17(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/addon-controls': 7.6.17(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@storybook/addon-docs': 7.6.17(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/addon-highlight': 7.6.17
       '@storybook/addon-measure': 7.6.17
       '@storybook/addon-outline': 7.6.17
       '@storybook/addon-toolbars': 7.6.17
       '@storybook/addon-viewport': 7.6.17
       '@storybook/core-common': 7.6.17
-      '@storybook/manager-api': 7.6.17(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/manager-api': 7.6.17(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/node-logger': 7.6.17
       '@storybook/preview-api': 7.6.17
       react: 18.2.0
@@ -12105,15 +12328,16 @@ snapshots:
     dependencies:
       '@storybook/csf': 0.1.4
       '@storybook/global': 5.0.0
-      react: 18.2.0
       ts-dedent: 2.2.0
+    optionalDependencies:
+      react: 18.2.0
 
   '@storybook/addon-measure@7.6.17':
     dependencies:
       '@storybook/global': 5.0.0
       tiny-invariant: 1.3.3
 
-  '@storybook/addon-onboarding@1.0.11(react-dom@18.2.0)(react@18.2.0)':
+  '@storybook/addon-onboarding@1.0.11(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@storybook/telemetry': 7.6.17
       react: 18.2.0
@@ -12128,7 +12352,7 @@ snapshots:
       '@storybook/global': 5.0.0
       ts-dedent: 2.2.0
 
-  '@storybook/addon-styling-webpack@0.0.6(webpack@5.90.3)':
+  '@storybook/addon-styling-webpack@0.0.6(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))':
     dependencies:
       '@storybook/node-logger': 7.6.17
       webpack: 5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)
@@ -12139,18 +12363,18 @@ snapshots:
     dependencies:
       memoizerific: 1.11.3
 
-  '@storybook/blocks@7.6.17(react-dom@18.2.0)(react@18.2.0)':
+  '@storybook/blocks@7.6.17(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@storybook/channels': 7.6.17
       '@storybook/client-logger': 7.6.17
-      '@storybook/components': 7.6.17(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/components': 7.6.17(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/core-events': 7.6.17
       '@storybook/csf': 0.1.4
       '@storybook/docs-tools': 7.6.17
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 7.6.17(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/manager-api': 7.6.17(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/preview-api': 7.6.17
-      '@storybook/theming': 7.6.17(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/theming': 7.6.17(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/types': 7.6.17
       '@types/lodash': 4.17.0
       color-convert: 2.0.1
@@ -12160,7 +12384,7 @@ snapshots:
       memoizerific: 1.11.3
       polished: 4.3.1
       react: 18.2.0
-      react-colorful: 5.6.1(react-dom@18.2.0)(react@18.2.0)
+      react-colorful: 5.6.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-dom: 18.2.0(react@18.2.0)
       telejson: 7.2.0
       tocbot: 4.25.0
@@ -12208,33 +12432,34 @@ snapshots:
       '@swc/core': 1.4.15
       '@types/node': 18.19.31
       '@types/semver': 7.5.8
-      babel-loader: 9.1.3(@babel/core@7.24.4)(webpack@5.90.3)
+      babel-loader: 9.1.3(@babel/core@7.24.4)(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.2.3
       constants-browserify: 1.0.0
-      css-loader: 6.11.0(webpack@5.90.3)
+      css-loader: 6.11.0(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))
       es-module-lexer: 1.4.1
       express: 4.19.2
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.3.3)(webpack@5.90.3)
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.3.3)(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))
       fs-extra: 11.2.0
-      html-webpack-plugin: 5.6.0(webpack@5.90.3)
+      html-webpack-plugin: 5.6.0(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))
       magic-string: 0.30.9
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.0
-      style-loader: 3.3.4(webpack@5.90.3)
-      swc-loader: 0.2.6(@swc/core@1.4.15)(webpack@5.90.3)
-      terser-webpack-plugin: 5.3.10(@swc/core@1.4.15)(esbuild@0.18.20)(webpack@5.90.3)
+      style-loader: 3.3.4(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))
+      swc-loader: 0.2.6(@swc/core@1.4.15)(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.4.15)(esbuild@0.18.20)(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))
       ts-dedent: 2.2.0
-      typescript: 5.3.3
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
       webpack: 5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)
-      webpack-dev-middleware: 6.1.3(webpack@5.90.3)
+      webpack-dev-middleware: 6.1.3(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.5.0
+    optionalDependencies:
+      typescript: 5.3.3
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/helpers'
@@ -12283,7 +12508,7 @@ snapshots:
       get-port: 5.1.1
       giget: 1.2.3
       globby: 11.1.0
-      jscodeshift: 0.15.2(@babel/preset-env@7.24.4)
+      jscodeshift: 0.15.2(@babel/preset-env@7.24.4(@babel/core@7.24.4))
       leven: 3.1.0
       ora: 5.4.1
       prettier: 2.8.8
@@ -12317,26 +12542,26 @@ snapshots:
       '@types/cross-spawn': 6.0.6
       cross-spawn: 7.0.3
       globby: 11.1.0
-      jscodeshift: 0.15.2(@babel/preset-env@7.24.4)
+      jscodeshift: 0.15.2(@babel/preset-env@7.24.4(@babel/core@7.24.4))
       lodash: 4.17.21
       prettier: 2.8.8
       recast: 0.23.6
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/components@7.6.17(react-dom@18.2.0)(react@18.2.0)':
+  '@storybook/components@7.6.17(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@radix-ui/react-select': 1.2.2(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-toolbar': 1.0.4(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-select': 1.2.2(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-toolbar': 1.0.4(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/client-logger': 7.6.17
       '@storybook/csf': 0.1.4
       '@storybook/global': 5.0.0
-      '@storybook/theming': 7.6.17(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/theming': 7.6.17(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/types': 7.6.17
       memoizerific: 1.11.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      use-resize-observer: 9.1.0(react-dom@18.2.0)(react@18.2.0)
+      use-resize-observer: 9.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       util-deprecate: 1.0.2
     transitivePeerDependencies:
       - '@types/react'
@@ -12482,7 +12707,7 @@ snapshots:
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/manager-api@7.6.17(react-dom@18.2.0)(react@18.2.0)':
+  '@storybook/manager-api@7.6.17(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@storybook/channels': 7.6.17
       '@storybook/client-logger': 7.6.17
@@ -12490,7 +12715,7 @@ snapshots:
       '@storybook/csf': 0.1.4
       '@storybook/global': 5.0.0
       '@storybook/router': 7.6.17
-      '@storybook/theming': 7.6.17(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/theming': 7.6.17(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/types': 7.6.17
       dequal: 2.0.3
       lodash: 4.17.21
@@ -12510,17 +12735,16 @@ snapshots:
 
   '@storybook/postinstall@7.6.17': {}
 
-  '@storybook/preset-react-webpack@7.6.17(@babel/core@7.24.4)(@swc/core@1.4.15)(esbuild@0.18.20)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@storybook/preset-react-webpack@7.6.17(@babel/core@7.24.4)(@swc/core@1.4.15)(esbuild@0.18.20)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@3.13.1)(typescript@5.3.3)(webpack-dev-server@4.15.2(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)))(webpack-hot-middleware@2.26.1)':
     dependencies:
-      '@babel/core': 7.24.4
       '@babel/preset-flow': 7.24.1(@babel/core@7.24.4)
       '@babel/preset-react': 7.24.1(@babel/core@7.24.4)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.14.0)(webpack@5.90.3)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.14.0)(type-fest@3.13.1)(webpack-dev-server@4.15.2(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)))(webpack-hot-middleware@2.26.1)(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))
       '@storybook/core-webpack': 7.6.17
       '@storybook/docs-tools': 7.6.17
       '@storybook/node-logger': 7.6.17
-      '@storybook/react': 7.6.17(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.3.3)(webpack@5.90.3)
+      '@storybook/react': 7.6.17(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.3.3)(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))
       '@types/node': 18.19.31
       '@types/semver': 7.5.8
       babel-plugin-add-react-displayname: 0.0.5
@@ -12531,8 +12755,10 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       react-refresh: 0.14.0
       semver: 7.6.0
-      typescript: 5.3.3
       webpack: 5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)
+    optionalDependencies:
+      '@babel/core': 7.24.4
+      typescript: 5.3.3
     transitivePeerDependencies:
       - '@swc/core'
       - '@types/webpack'
@@ -12566,7 +12792,7 @@ snapshots:
 
   '@storybook/preview@7.6.17': {}
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.3.3)(webpack@5.90.3)':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.3.3)(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))':
     dependencies:
       debug: 4.3.4(supports-color@5.5.0)
       endent: 2.1.0
@@ -12580,20 +12806,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-dom-shim@7.6.17(react-dom@18.2.0)(react@18.2.0)':
+  '@storybook/react-dom-shim@7.6.17(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@storybook/react-webpack5@7.6.17(@babel/core@7.24.4)(@swc/core@1.4.15)(esbuild@0.18.20)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@storybook/react-webpack5@7.6.17(@babel/core@7.24.4)(@swc/core@1.4.15)(esbuild@0.18.20)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@3.13.1)(typescript@5.3.3)(webpack-dev-server@4.15.2(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)))(webpack-hot-middleware@2.26.1)':
     dependencies:
-      '@babel/core': 7.24.4
       '@storybook/builder-webpack5': 7.6.17(esbuild@0.18.20)(typescript@5.3.3)
-      '@storybook/preset-react-webpack': 7.6.17(@babel/core@7.24.4)(@swc/core@1.4.15)(esbuild@0.18.20)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@storybook/react': 7.6.17(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@storybook/preset-react-webpack': 7.6.17(@babel/core@7.24.4)(@swc/core@1.4.15)(esbuild@0.18.20)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@3.13.1)(typescript@5.3.3)(webpack-dev-server@4.15.2(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)))(webpack-hot-middleware@2.26.1)
+      '@storybook/react': 7.6.17(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@types/node': 18.19.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@babel/core': 7.24.4
       typescript: 5.3.3
     transitivePeerDependencies:
       - '@rspack/core'
@@ -12611,14 +12838,14 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/react@7.6.17(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@storybook/react@7.6.17(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
       '@storybook/client-logger': 7.6.17
       '@storybook/core-client': 7.6.17
       '@storybook/docs-tools': 7.6.17
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 7.6.17
-      '@storybook/react-dom-shim': 7.6.17(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/react-dom-shim': 7.6.17(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/types': 7.6.17
       '@types/escodegen': 0.0.6
       '@types/estree': 0.0.51
@@ -12632,11 +12859,12 @@ snapshots:
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-element-to-jsx-string: 15.0.0(react-dom@18.2.0)(react@18.2.0)
+      react-element-to-jsx-string: 15.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       ts-dedent: 2.2.0
       type-fest: 2.19.0
-      typescript: 5.3.3
       util-deprecate: 1.0.2
+    optionalDependencies:
+      typescript: 5.3.3
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -12661,7 +12889,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/theming@7.6.17(react-dom@18.2.0)(react@18.2.0)':
+  '@storybook/theming@7.6.17(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
       '@storybook/client-logger': 7.6.17
@@ -13105,7 +13333,7 @@ snapshots:
       '@types/node': 20.12.7
     optional: true
 
-  '@typescript-eslint/eslint-plugin@6.10.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.0)(typescript@5.3.3)':
+  '@typescript-eslint/eslint-plugin@6.10.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
@@ -13120,6 +13348,7 @@ snapshots:
       natural-compare: 1.4.0
       semver: 7.6.0
       ts-api-utils: 1.3.0(typescript@5.3.3)
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -13132,6 +13361,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.57.0
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -13153,6 +13383,7 @@ snapshots:
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.3.3)
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -13170,6 +13401,7 @@ snapshots:
       is-glob: 4.0.3
       semver: 7.6.0
       ts-api-utils: 1.3.0(typescript@5.3.3)
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -13184,6 +13416,7 @@ snapshots:
       minimatch: 9.0.3
       semver: 7.6.0
       ts-api-utils: 1.3.0(typescript@5.3.3)
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -13352,7 +13585,7 @@ snapshots:
       indent-string: 4.0.0
 
   ajv-formats@2.1.1(ajv@8.12.0):
-    dependencies:
+    optionalDependencies:
       ajv: 8.12.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
@@ -13577,12 +13810,19 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.4
 
-  babel-loader@9.1.3(@babel/core@7.24.4)(webpack@5.90.3):
+  babel-loader@9.1.3(@babel/core@7.24.4)(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)):
     dependencies:
       '@babel/core': 7.24.4
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)
+
+  babel-loader@9.1.3(@babel/core@7.24.4)(webpack@5.90.3(@swc/core@1.4.15)):
+    dependencies:
+      '@babel/core': 7.24.4
+      find-cache-dir: 4.0.0
+      schema-utils: 4.2.0
+      webpack: 5.90.3(@swc/core@1.4.15)
 
   babel-plugin-add-react-displayname@0.0.5: {}
 
@@ -14091,7 +14331,7 @@ snapshots:
 
   copy-text-to-clipboard@3.2.0: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.90.3):
+  copy-webpack-plugin@11.0.0(webpack@5.90.3(@swc/core@1.4.15)):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -14099,7 +14339,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
 
   core-js-compat@3.36.1:
     dependencies:
@@ -14133,6 +14373,7 @@ snapshots:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
+    optionalDependencies:
       typescript: 5.3.3
 
   create-require@1.1.1: {}
@@ -14165,7 +14406,7 @@ snapshots:
     dependencies:
       postcss: 8.4.38
 
-  css-loader@5.2.7(webpack@5.90.3):
+  css-loader@5.2.7(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       loader-utils: 2.0.4
@@ -14179,7 +14420,7 @@ snapshots:
       semver: 7.6.0
       webpack: 5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)
 
-  css-loader@6.11.0(webpack@5.90.3):
+  css-loader@6.11.0(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
@@ -14189,18 +14430,33 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
       semver: 7.6.0
-      webpack: 5.90.3
+    optionalDependencies:
+      webpack: 5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)
 
-  css-minimizer-webpack-plugin@4.2.2(clean-css@5.3.3)(webpack@5.90.3):
+  css-loader@6.11.0(webpack@5.90.3(@swc/core@1.4.15)):
     dependencies:
-      clean-css: 5.3.3
+      icss-utils: 5.1.0(postcss@8.4.38)
+      postcss: 8.4.38
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.38)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.4.38)
+      postcss-modules-scope: 3.2.0(postcss@8.4.38)
+      postcss-modules-values: 4.0.0(postcss@8.4.38)
+      postcss-value-parser: 4.2.0
+      semver: 7.6.0
+    optionalDependencies:
+      webpack: 5.90.3(@swc/core@1.4.15)
+
+  css-minimizer-webpack-plugin@4.2.2(clean-css@5.3.3)(webpack@5.90.3(@swc/core@1.4.15)):
+    dependencies:
       cssnano: 5.1.15(postcss@8.4.38)
       jest-worker: 29.7.0
       postcss: 8.4.38
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
       source-map: 0.6.1
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
+    optionalDependencies:
+      clean-css: 5.3.3
 
   css-select@4.3.0:
     dependencies:
@@ -14339,6 +14595,7 @@ snapshots:
   debug@4.3.4(supports-color@5.5.0):
     dependencies:
       ms: 2.1.2
+    optionalDependencies:
       supports-color: 5.5.0
 
   decamelize-keys@1.1.1:
@@ -14787,7 +15044,7 @@ snapshots:
       eslint: 8.57.0
       semver: 7.6.0
 
-  eslint-config-eslint@7.0.0(eslint-plugin-jsdoc@48.2.3)(eslint-plugin-node@11.1.0):
+  eslint-config-eslint@7.0.0(eslint-plugin-jsdoc@48.2.3(eslint@8.57.0))(eslint-plugin-node@11.1.0(eslint@8.57.0)):
     dependencies:
       eslint-plugin-jsdoc: 48.2.3(eslint@8.57.0)
       eslint-plugin-node: 11.1.0(eslint@8.57.0)
@@ -14796,10 +15053,10 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.25.2)(eslint-plugin-n@16.6.2)(eslint-plugin-promise@6.1.1)(eslint@8.57.0):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.25.2(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint-plugin-n@16.6.2(eslint@8.57.0))(eslint-plugin-promise@6.1.1(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
-      eslint-plugin-import: 2.25.2(@typescript-eslint/parser@6.21.0)(eslint@8.57.0)
+      eslint-plugin-import: 2.25.2(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)
       eslint-plugin-n: 16.6.2(eslint@8.57.0)
       eslint-plugin-promise: 6.1.1(eslint@8.57.0)
 
@@ -14811,10 +15068,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     dependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
       debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -14833,16 +15091,15 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-import@2.25.2(@typescript-eslint/parser@6.21.0)(eslint@8.57.0):
+  eslint-plugin-import@2.25.2(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0):
     dependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
       array-includes: 3.1.8
       array.prototype.flat: 1.3.2
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       has: 1.0.4
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -14850,6 +15107,8 @@ snapshots:
       object.values: 1.2.0
       resolve: 1.22.8
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -14945,11 +15204,12 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.11
 
-  eslint-plugin-unused-imports@3.1.0(@typescript-eslint/eslint-plugin@6.10.0)(eslint@8.57.0):
+  eslint-plugin-unused-imports@3.1.0(@typescript-eslint/eslint-plugin@6.10.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.10.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.0)(typescript@5.3.3)
       eslint: 8.57.0
       eslint-rule-composer: 0.3.0
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 6.10.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)
 
   eslint-rule-composer@0.3.0: {}
 
@@ -15250,11 +15510,11 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
-  file-loader@6.2.0(webpack@5.90.3):
+  file-loader@6.2.0(webpack@5.90.3(@swc/core@1.4.15)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
 
   file-system-cache@2.3.0:
     dependencies:
@@ -15343,7 +15603,7 @@ snapshots:
   flow-parser@0.233.0: {}
 
   follow-redirects@1.15.6(debug@4.3.4):
-    dependencies:
+    optionalDependencies:
       debug: 4.3.4(supports-color@5.5.0)
 
   for-each@0.3.3:
@@ -15355,7 +15615,7 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@8.57.0)(typescript@5.3.3)(webpack@5.90.3):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@8.57.0)(typescript@5.3.3)(webpack@5.90.3(@swc/core@1.4.15)):
     dependencies:
       '@babel/code-frame': 7.24.2
       '@types/json-schema': 7.0.15
@@ -15363,7 +15623,6 @@ snapshots:
       chokidar: 3.6.0
       cosmiconfig: 6.0.0
       deepmerge: 4.3.1
-      eslint: 8.57.0
       fs-extra: 9.1.0
       glob: 7.2.3
       memfs: 3.5.3
@@ -15372,9 +15631,11 @@ snapshots:
       semver: 7.6.0
       tapable: 1.1.3
       typescript: 5.3.3
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
+    optionalDependencies:
+      eslint: 8.57.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.3.3)(webpack@5.90.3):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.3.3)(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)):
     dependencies:
       '@babel/code-frame': 7.24.2
       chalk: 4.1.2
@@ -15866,14 +16127,25 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.0(webpack@5.90.3):
+  html-webpack-plugin@5.6.0(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.90.3
+    optionalDependencies:
+      webpack: 5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)
+
+  html-webpack-plugin@5.6.0(webpack@5.90.3(@swc/core@1.4.15)):
+    dependencies:
+      '@types/html-minifier-terser': 6.1.0
+      html-minifier-terser: 6.1.0
+      lodash: 4.17.21
+      pretty-error: 4.0.0
+      tapable: 2.2.1
+    optionalDependencies:
+      webpack: 5.90.3(@swc/core@1.4.15)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -15919,12 +16191,13 @@ snapshots:
 
   http-proxy-middleware@2.0.6(@types/express@4.17.21)(debug@4.3.4):
     dependencies:
-      '@types/express': 4.17.21
       '@types/http-proxy': 1.17.14
       http-proxy: 1.18.1(debug@4.3.4)
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.5
+    optionalDependencies:
+      '@types/express': 4.17.21
     transitivePeerDependencies:
       - debug
 
@@ -16369,7 +16642,7 @@ snapshots:
 
   jsbn@1.1.0: {}
 
-  jscodeshift@0.15.2(@babel/preset-env@7.24.4):
+  jscodeshift@0.15.2(@babel/preset-env@7.24.4(@babel/core@7.24.4)):
     dependencies:
       '@babel/core': 7.24.4
       '@babel/parser': 7.24.4
@@ -16378,7 +16651,6 @@ snapshots:
       '@babel/plugin-transform-nullish-coalescing-operator': 7.24.1(@babel/core@7.24.4)
       '@babel/plugin-transform-optional-chaining': 7.24.1(@babel/core@7.24.4)
       '@babel/plugin-transform-private-methods': 7.24.1(@babel/core@7.24.4)
-      '@babel/preset-env': 7.24.4(@babel/core@7.24.4)
       '@babel/preset-flow': 7.24.1(@babel/core@7.24.4)
       '@babel/preset-typescript': 7.24.1(@babel/core@7.24.4)
       '@babel/register': 7.23.7(@babel/core@7.24.4)
@@ -16392,6 +16664,8 @@ snapshots:
       recast: 0.23.6
       temp: 0.8.4
       write-file-atomic: 2.4.3
+    optionalDependencies:
+      '@babel/preset-env': 7.24.4(@babel/core@7.24.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -17233,11 +17507,11 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.0(webpack@5.90.3):
+  mini-css-extract-plugin@2.9.0(webpack@5.90.3(@swc/core@1.4.15)):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
 
   minimalistic-assert@1.0.1: {}
 
@@ -17769,19 +18043,21 @@ snapshots:
       postcss: 8.4.38
       postcss-selector-parser: 6.0.16
 
-  postcss-load-config@3.1.4(postcss@8.4.38):
+  postcss-load-config@3.1.4(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3)):
     dependencies:
       lilconfig: 2.1.0
-      postcss: 8.4.38
       yaml: 1.10.2
+    optionalDependencies:
+      postcss: 8.4.38
+      ts-node: 10.9.2(@swc/core@1.4.15)(@types/node@20.12.7)(typescript@5.3.3)
 
-  postcss-loader@7.3.4(postcss@8.4.38)(typescript@5.3.3)(webpack@5.90.3):
+  postcss-loader@7.3.4(postcss@8.4.38)(typescript@5.3.3)(webpack@5.90.3(@swc/core@1.4.15)):
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.3.3)
       jiti: 1.21.0
       postcss: 8.4.38
       semver: 7.6.0
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
     transitivePeerDependencies:
       - typescript
 
@@ -18137,7 +18413,7 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-colorful@5.6.1(react-dom@18.2.0)(react@18.2.0):
+  react-colorful@5.6.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -18147,7 +18423,7 @@ snapshots:
       react: 18.2.0
       tween-functions: 1.2.0
 
-  react-dev-utils@12.0.1(eslint@8.57.0)(typescript@5.3.3)(webpack@5.90.3):
+  react-dev-utils@12.0.1(eslint@8.57.0)(typescript@5.3.3)(webpack@5.90.3(@swc/core@1.4.15)):
     dependencies:
       '@babel/code-frame': 7.24.2
       address: 1.2.2
@@ -18158,7 +18434,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.57.0)(typescript@5.3.3)(webpack@5.90.3)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.57.0)(typescript@5.3.3)(webpack@5.90.3(@swc/core@1.4.15))
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -18173,8 +18449,9 @@ snapshots:
       shell-quote: 1.8.1
       strip-ansi: 6.0.1
       text-table: 0.2.0
+      webpack: 5.90.3(@swc/core@1.4.15)
+    optionalDependencies:
       typescript: 5.3.3
-      webpack: 5.90.3
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -18205,7 +18482,7 @@ snapshots:
       react: 18.2.0
       scheduler: 0.23.0
 
-  react-element-to-jsx-string@15.0.0(react-dom@18.2.0)(react@18.2.0):
+  react-element-to-jsx-string@15.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@base2/pretty-print-object': 1.0.1
       is-plain-object: 5.0.0
@@ -18217,7 +18494,7 @@ snapshots:
 
   react-fast-compare@3.2.2: {}
 
-  react-helmet-async@1.3.0(react-dom@18.2.0)(react@18.2.0):
+  react-helmet-async@1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.23.9
       invariant: 2.2.4
@@ -18227,7 +18504,7 @@ snapshots:
       react-fast-compare: 3.2.2
       shallowequal: 1.1.0
 
-  react-helmet-async@2.0.4(react-dom@18.2.0)(react@18.2.0):
+  react-helmet-async@2.0.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       invariant: 2.2.4
       react: 18.2.0
@@ -18243,30 +18520,34 @@ snapshots:
     dependencies:
       react: 18.2.0
 
-  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@5.5.2)(webpack@5.90.3):
+  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@5.5.2(react@18.2.0))(webpack@5.90.3(@swc/core@1.4.15)):
     dependencies:
       '@babel/runtime': 7.23.9
       react-loadable: '@docusaurus/react-loadable@5.5.2(react@18.2.0)'
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
 
   react-refresh@0.14.0: {}
 
-  react-remove-scroll-bar@2.3.6(react@18.2.0):
+  react-remove-scroll-bar@2.3.6(@types/react@18.2.75)(react@18.2.0):
     dependencies:
       react: 18.2.0
-      react-style-singleton: 2.2.1(react@18.2.0)
+      react-style-singleton: 2.2.1(@types/react@18.2.75)(react@18.2.0)
       tslib: 2.6.2
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  react-remove-scroll@2.5.5(react@18.2.0):
+  react-remove-scroll@2.5.5(@types/react@18.2.75)(react@18.2.0):
     dependencies:
       react: 18.2.0
-      react-remove-scroll-bar: 2.3.6(react@18.2.0)
-      react-style-singleton: 2.2.1(react@18.2.0)
+      react-remove-scroll-bar: 2.3.6(@types/react@18.2.75)(react@18.2.0)
+      react-style-singleton: 2.2.1(@types/react@18.2.75)(react@18.2.0)
       tslib: 2.6.2
-      use-callback-ref: 1.3.2(react@18.2.0)
-      use-sidecar: 1.1.2(react@18.2.0)
+      use-callback-ref: 1.3.2(@types/react@18.2.75)(react@18.2.0)
+      use-sidecar: 1.1.2(@types/react@18.2.75)(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  react-router-config@5.1.1(react-router@5.3.4)(react@18.2.0):
+  react-router-config@5.1.1(react-router@5.3.4(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.23.9
       react: 18.2.0
@@ -18296,12 +18577,14 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  react-style-singleton@2.2.1(react@18.2.0):
+  react-style-singleton@2.2.1(@types/react@18.2.75)(react@18.2.0):
     dependencies:
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 18.2.0
       tslib: 2.6.2
+    optionalDependencies:
+      '@types/react': 18.2.75
 
   react@18.2.0:
     dependencies:
@@ -18583,7 +18866,7 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rollup-plugin-postcss@4.0.2(postcss@8.4.38):
+  rollup-plugin-postcss@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3)):
     dependencies:
       chalk: 4.1.2
       concat-with-sourcemaps: 1.1.0
@@ -18592,7 +18875,7 @@ snapshots:
       p-queue: 6.6.2
       pify: 5.0.0
       postcss: 8.4.38
-      postcss-load-config: 3.1.4(postcss@8.4.38)
+      postcss-load-config: 3.1.4(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3))
       postcss-modules: 4.3.1(postcss@8.4.38)
       promise.series: 0.2.0
       resolve: 1.22.8
@@ -18670,15 +18953,16 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@10.5.2(sass@1.75.0)(webpack@5.90.3):
+  sass-loader@10.5.2(sass@1.75.0)(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)):
     dependencies:
       klona: 2.0.6
       loader-utils: 2.0.4
       neo-async: 2.6.2
-      sass: 1.75.0
       schema-utils: 3.3.0
       semver: 7.6.0
       webpack: 5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)
+    optionalDependencies:
+      sass: 1.75.0
 
   sass@1.75.0:
     dependencies:
@@ -19172,13 +19456,13 @@ snapshots:
 
   style-inject@0.3.0: {}
 
-  style-loader@2.0.0(webpack@5.90.3):
+  style-loader@2.0.0(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
       webpack: 5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)
 
-  style-loader@3.3.4(webpack@5.90.3):
+  style-loader@3.3.4(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)):
     dependencies:
       webpack: 5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)
 
@@ -19222,7 +19506,7 @@ snapshots:
       picocolors: 1.0.0
       stable: 0.1.8
 
-  swc-loader@0.2.6(@swc/core@1.4.15)(webpack@5.90.3):
+  swc-loader@0.2.6(@swc/core@1.4.15)(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)):
     dependencies:
       '@swc/core': 1.4.15
       '@swc/counter': 0.1.3
@@ -19292,16 +19576,28 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.4.15)(esbuild@0.18.20)(webpack@5.90.3):
+  terser-webpack-plugin@5.3.10(@swc/core@1.4.15)(esbuild@0.18.20)(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      '@swc/core': 1.4.15
-      esbuild: 0.18.20
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.28.1
       webpack: 5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)
+    optionalDependencies:
+      '@swc/core': 1.4.15
+      esbuild: 0.18.20
+
+  terser-webpack-plugin@5.3.10(@swc/core@1.4.15)(webpack@5.90.3(@swc/core@1.4.15)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.28.1
+      webpack: 5.90.3(@swc/core@1.4.15)
+    optionalDependencies:
+      '@swc/core': 1.4.15
 
   terser-webpack-plugin@5.3.10(webpack@5.90.3):
     dependencies:
@@ -19378,7 +19674,7 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3):
+  ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.12.7)(typescript@5.3.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -19395,6 +19691,8 @@ snapshots:
       typescript: 5.3.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.4.15
 
   tsconfig-paths-webpack-plugin@3.5.2:
     dependencies:
@@ -19669,13 +19967,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0)(webpack@5.90.3):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.90.3(@swc/core@1.4.15)))(webpack@5.90.3(@swc/core@1.4.15)):
     dependencies:
-      file-loader: 6.2.0(webpack@5.90.3)
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
+    optionalDependencies:
+      file-loader: 6.2.0(webpack@5.90.3(@swc/core@1.4.15))
 
   url@0.11.3:
     dependencies:
@@ -19684,22 +19983,26 @@ snapshots:
 
   urlpattern-polyfill@10.0.0: {}
 
-  use-callback-ref@1.3.2(react@18.2.0):
+  use-callback-ref@1.3.2(@types/react@18.2.75)(react@18.2.0):
     dependencies:
       react: 18.2.0
       tslib: 2.6.2
+    optionalDependencies:
+      '@types/react': 18.2.75
 
-  use-resize-observer@9.1.0(react-dom@18.2.0)(react@18.2.0):
+  use-resize-observer@9.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@juggle/resize-observer': 3.4.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  use-sidecar@1.1.2(react@18.2.0):
+  use-sidecar@1.1.2(@types/react@18.2.75)(react@18.2.0):
     dependencies:
       detect-node-es: 1.1.0
       react: 18.2.0
       tslib: 2.6.2
+    optionalDependencies:
+      '@types/react': 18.2.75
 
   util-deprecate@1.0.2: {}
 
@@ -19787,16 +20090,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@5.3.4(webpack@5.90.3):
-    dependencies:
-      colorette: 2.0.20
-      memfs: 3.5.3
-      mime-types: 2.1.35
-      range-parser: 1.2.1
-      schema-utils: 4.2.0
-      webpack: 5.90.3
-
-  webpack-dev-middleware@6.1.3(webpack@5.90.3):
+  webpack-dev-middleware@5.3.4(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -19804,8 +20098,28 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
       webpack: 5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)
+    optional: true
 
-  webpack-dev-server@4.15.2(debug@4.3.4)(webpack@5.90.3):
+  webpack-dev-middleware@5.3.4(webpack@5.90.3(@swc/core@1.4.15)):
+    dependencies:
+      colorette: 2.0.20
+      memfs: 3.5.3
+      mime-types: 2.1.35
+      range-parser: 1.2.1
+      schema-utils: 4.2.0
+      webpack: 5.90.3(@swc/core@1.4.15)
+
+  webpack-dev-middleware@6.1.3(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)):
+    dependencies:
+      colorette: 2.0.20
+      memfs: 3.5.3
+      mime-types: 2.1.35
+      range-parser: 1.2.1
+      schema-utils: 4.2.0
+    optionalDependencies:
+      webpack: 5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)
+
+  webpack-dev-server@4.15.2(debug@4.3.4)(webpack@5.90.3(@swc/core@1.4.15)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -19835,9 +20149,91 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.90.3
-      webpack-dev-middleware: 5.3.4(webpack@5.90.3)
+      webpack-dev-middleware: 5.3.4(webpack@5.90.3(@swc/core@1.4.15))
       ws: 8.16.0
+    optionalDependencies:
+      webpack: 5.90.3(@swc/core@1.4.15)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  webpack-dev-server@4.15.2(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)):
+    dependencies:
+      '@types/bonjour': 3.5.13
+      '@types/connect-history-api-fallback': 1.5.4
+      '@types/express': 4.17.21
+      '@types/serve-index': 1.9.4
+      '@types/serve-static': 1.15.7
+      '@types/sockjs': 0.3.36
+      '@types/ws': 8.5.10
+      ansi-html-community: 0.0.8
+      bonjour-service: 1.2.1
+      chokidar: 3.6.0
+      colorette: 2.0.20
+      compression: 1.7.4
+      connect-history-api-fallback: 2.0.0
+      default-gateway: 6.0.3
+      express: 4.19.2
+      graceful-fs: 4.2.11
+      html-entities: 2.5.2
+      http-proxy-middleware: 2.0.6(@types/express@4.17.21)(debug@4.3.4)
+      ipaddr.js: 2.1.0
+      launch-editor: 2.6.1
+      open: 8.4.2
+      p-retry: 4.6.2
+      rimraf: 3.0.2
+      schema-utils: 4.2.0
+      selfsigned: 2.4.1
+      serve-index: 1.9.1
+      sockjs: 0.3.24
+      spdy: 4.0.2
+      webpack-dev-middleware: 5.3.4(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))
+      ws: 8.16.0
+    optionalDependencies:
+      webpack: 5.90.3(@swc/core@1.4.15)(esbuild@0.18.20)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+    optional: true
+
+  webpack-dev-server@4.15.2(webpack@5.90.3(@swc/core@1.4.15)):
+    dependencies:
+      '@types/bonjour': 3.5.13
+      '@types/connect-history-api-fallback': 1.5.4
+      '@types/express': 4.17.21
+      '@types/serve-index': 1.9.4
+      '@types/serve-static': 1.15.7
+      '@types/sockjs': 0.3.36
+      '@types/ws': 8.5.10
+      ansi-html-community: 0.0.8
+      bonjour-service: 1.2.1
+      chokidar: 3.6.0
+      colorette: 2.0.20
+      compression: 1.7.4
+      connect-history-api-fallback: 2.0.0
+      default-gateway: 6.0.3
+      express: 4.19.2
+      graceful-fs: 4.2.11
+      html-entities: 2.5.2
+      http-proxy-middleware: 2.0.6(@types/express@4.17.21)(debug@4.3.4)
+      ipaddr.js: 2.1.0
+      launch-editor: 2.6.1
+      open: 8.4.2
+      p-retry: 4.6.2
+      rimraf: 3.0.2
+      schema-utils: 4.2.0
+      selfsigned: 2.4.1
+      serve-index: 1.9.1
+      sockjs: 0.3.24
+      spdy: 4.0.2
+      webpack-dev-middleware: 5.3.4(webpack@5.90.3(@swc/core@1.4.15))
+      ws: 8.16.0
+    optionalDependencies:
+      webpack: 5.90.3(@swc/core@1.4.15)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -19893,6 +20289,37 @@ snapshots:
       - esbuild
       - uglify-js
 
+  webpack@5.90.3(@swc/core@1.4.15):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.5
+      '@webassemblyjs/ast': 1.11.6
+      '@webassemblyjs/wasm-edit': 1.11.6
+      '@webassemblyjs/wasm-parser': 1.11.6
+      acorn: 8.11.3
+      acorn-import-assertions: 1.9.0(acorn@8.11.3)
+      browserslist: 4.23.0
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.15.1
+      es-module-lexer: 1.4.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(@swc/core@1.4.15)(webpack@5.90.3(@swc/core@1.4.15))
+      watchpack: 2.4.0
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
   webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20):
     dependencies:
       '@types/eslint-scope': 3.7.7
@@ -19916,7 +20343,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.4.15)(esbuild@0.18.20)(webpack@5.90.3)
+      terser-webpack-plugin: 5.3.10(@swc/core@1.4.15)(esbuild@0.18.20)(webpack@5.90.3(@swc/core@1.4.15)(esbuild@0.18.20))
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -19924,13 +20351,13 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpackbar@5.0.2(webpack@5.90.3):
+  webpackbar@5.0.2(webpack@5.90.3(@swc/core@1.4.15)):
     dependencies:
       chalk: 4.1.2
       consola: 2.15.3
       pretty-time: 1.1.0
       std-env: 3.7.0
-      webpack: 5.90.3
+      webpack: 5.90.3(@swc/core@1.4.15)
 
   websocket-driver@0.7.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@size-limit/preset-big-lib':
         specifier: ^11.0.2
         version: 11.0.2(size-limit@11.0.2)
+      core-js:
+        specifier: ^3.29.0
+        version: 3.37.0
       glob:
         specifier: ^9.3.4
         version: 9.3.5
@@ -172,9 +175,6 @@ importers:
       '@types/react':
         specifier: ^18.2.75
         version: 18.2.75
-      core-js:
-        specifier: ^3.29.0
-        version: 3.37.0
       rollup:
         specifier: ^2.79.1
         version: 2.79.1

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://turborepo.org/schema.json",
     "pipeline": {
-        "build": {"cache": false, "outputs": ["dist/**"]},
+        "build": {"cache": false, "outputs": ["dist/**"], "dependsOn": ["^build"]},
         "lint": {"cache": false},
         "lint:fix": {"cache": false},
         "prettier": {"cache": false},


### PR DESCRIPTION
## Related Issue <!-- #뒤에 이슈번호 작성 -->

#50 
https://github.com/NaverPayDev/code-style/issues/28

## Describe your changes <!-- PR의 주요 작업 내용 작성 -->

- svg-manager를 이관합니다. 

## Request <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->

- getSecureMathRandom를 common-utils에서 가져오도록 수정이 필요합니다. 
- eslint plugin 이관 후 plugin 관련 설명 추가 필요 
