### PR TITLE
Fix/empty string case

### DIFF
--- a/.changeset/nervous-moles-itch.md
+++ b/.changeset/nervous-moles-itch.md
@@ -1,0 +1,5 @@
+---
+"@naverpay/utils": patch
+---
+
+한글 관련 유틸리티 함수의 빈 문자열 및 undefined에 대한 예외 처리를 추가합니다

--- a/packages/utils/src/utils/disassemble문자.ts
+++ b/packages/utils/src/utils/disassemble문자.ts
@@ -7,8 +7,8 @@ import 한글_여부 from './한글_여부'
  * '가' 문자로 부터 차이를 구한 뒤, 그 차이를 28로 나눈 나머지가 0 이라면 받침이 없는 글자입니다.
  * @returns {first:string, middle:string, last:string} | undefined (한글이 아닌경우)
  */
-const disassemble문자 = (letter: string) => {
-    if (!한글_여부(letter)) {
+const disassemble문자 = (letter: string | undefined) => {
+    if (letter === undefined || !한글_여부(letter)) {
         return undefined
     }
     const charCode = letter.charCodeAt(0)

--- a/packages/utils/src/utils/disassemble문자.ts
+++ b/packages/utils/src/utils/disassemble문자.ts
@@ -7,8 +7,8 @@ import 한글_여부 from './한글_여부'
  * '가' 문자로 부터 차이를 구한 뒤, 그 차이를 28로 나눈 나머지가 0 이라면 받침이 없는 글자입니다.
  * @returns {first:string, middle:string, last:string} | undefined (한글이 아닌경우)
  */
-const disassemble문자 = (letter: string | undefined) => {
-    if (letter === undefined || !한글_여부(letter)) {
+const disassemble문자 = (letter: string) => {
+    if (!letter || !한글_여부(letter)) {
         return undefined
     }
     const charCode = letter.charCodeAt(0)

--- a/packages/utils/src/utils/마지막_문자_받침_여부.ts
+++ b/packages/utils/src/utils/마지막_문자_받침_여부.ts
@@ -9,7 +9,7 @@ const 마지막_문자_받침_여부 = (word: string) => {
     const 마지막_문자 = word.slice(-1)
     const charCode = 마지막_문자.charCodeAt(0)
 
-    return 한글_여부(마지막_문자) && (charCode - 가_CHAR_CODE) % 28 !== 0
+    return !isNaN(charCode) && 한글_여부(마지막_문자) && (charCode - 가_CHAR_CODE) % 28 !== 0
 }
 
 export default 마지막_문자_받침_여부

--- a/packages/utils/src/utils/한글_여부.ts
+++ b/packages/utils/src/utils/한글_여부.ts
@@ -6,7 +6,7 @@ import {가_CHAR_CODE, 힣_CHAR_CODE} from '../constants/hangul'
  */
 const 한글_여부 = (letter: string) => {
     const charCode = letter.charCodeAt(0)
-    if (charCode < 가_CHAR_CODE || charCode > 힣_CHAR_CODE) {
+    if (isNaN(charCode) || charCode < 가_CHAR_CODE || charCode > 힣_CHAR_CODE) {
         return false
     }
     return true


### PR DESCRIPTION
## Related Issue <!-- #뒤에 이슈번호 작성 -->

- https://github.com/NaverPayDev/pie/issues/76

## Describe your changes <!-- PR의 주요 작업 내용 작성 -->

- `''.charCodeAt(0)`  NaN에 대한 예외처리
- `''[''.length -1].charCodeAt()` undefined case 예외처리

## Request <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->
before:
-  `console.log(한글_여부('')) //  output: true`
-  `console.log(마지막_문자_받침_여부('')) //  output: true`
-  `console.log(disassemble문자('')) //  output: {first: undefined, middle: undefined, last: undefined}`
-  `console.log(get조사('', '와/과')); // Cannot read properties of undefined (reading 'charCodeAt')`

after: 
-  `console.log(한글_여부('')) //  output: false`
-  `console.log(마지막_문자_받침_여부('')) //  output: false`
-  `console.log(disassemble문자('')) //  output: undefined`
-  `console.log(get조사('', '와/과')); // output: '와'`