### PR TITLE
[react-pdf] pdf에 삽입된 스크립트를 실행하는 isEvalSupported 파라미터를 false로 변경합니다.

### DIFF
--- a/.changeset/kind-eyes-sell.md
+++ b/.changeset/kind-eyes-sell.md
@@ -1,0 +1,5 @@
+---
+"@naverpay/react-pdf": patch
+---
+
+[react-pdf] pdf에 삽입된 스크립트를 실행하는 isEvalSupported 파라미터를 false로 변경합니다.

--- a/packages/react-pdf/src/utils/pdf.ts
+++ b/packages/react-pdf/src/utils/pdf.ts
@@ -92,7 +92,7 @@ export async function getPdfDocument({
         source = {...source, cMapPacked}
     }
 
-    const {promise} = pdfjs.getDocument({...source}) as PDFLoadingTask<PDFDocumentProxy>
+    const {promise} = pdfjs.getDocument({...source, isEvalSupported: false}) as PDFLoadingTask<PDFDocumentProxy>
     const pdfInfo = await promise
     return pdfInfo
 }


### PR DESCRIPTION
## Related Issue <!-- #뒤에 이슈번호 작성 -->

- #79

## Describe your changes <!-- PR의 주요 작업 내용 작성 -->

- pdf에 삽입된 스크립트를 실행하는 isEvalSupported 파라미터를 false로 변경합니다.
- pdf-dist js 중 eval code를 실행시키는 파라미터가 존재합니다.
- pdf 내부에 js가 삽입되어 있는 경우 XSS 공격이 가능합니다.
- 이를 방어하기 위해, 코드를 수정합니다.
- 로컬에서 확인해보고 draft 풀겠습니다

## Request <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->

-
