### PR TITLE
[svg-manager] react 17 + ESM 지원을 위해 runtime: 'classic' 으로 변경

### DIFF
--- a/.changeset/forty-toes-appear.md
+++ b/.changeset/forty-toes-appear.md
@@ -1,0 +1,5 @@
+---
+"@naverpay/svg-manager": patch
+---
+
+[svg-manager] react 17 + ESM 지원을 위해 runtime: 'classic' 으로 변경

--- a/packages/svg-manager/rollup.config.js
+++ b/packages/svg-manager/rollup.config.js
@@ -4,5 +4,5 @@ module.exports = generateRollupConfig({
     packageDir: __dirname,
     entrypoint: './src/index.ts',
     minify: false,
-    react: {runtime: 'automatic'},
+    react: {runtime: 'classic'},
 })

--- a/packages/svg-manager/src/SvgUniqueID.tsx
+++ b/packages/svg-manager/src/SvgUniqueID.tsx
@@ -1,4 +1,4 @@
-import {PropsWithChildren, ReactElement, cloneElement} from 'react'
+import React, {PropsWithChildren, ReactElement, cloneElement} from 'react'
 
 import {generateRandomString, toSingleton} from './utils'
 import deepMap from './utils/deepMap'

--- a/packages/svg-manager/tsconfig.json
+++ b/packages/svg-manager/tsconfig.json
@@ -4,7 +4,8 @@
         "baseUrl": ".",
         "outDir": "./dist/cjs",
         "rootDir": "./src",
-        "emitDeclarationOnly": true
+        "emitDeclarationOnly": true,
+        "noUnusedLocals": false
     },
     "include": ["./src", "./typings"],
     "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Related Issue  #81

## Describe your changes <!-- PR의 주요 작업 내용 작성 -->

- runtime을 변경하고 tsconfig에서 unusedVars를 체크하지 않도록 변경합니다.

## Request <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->

-
