### PR TITLE
[react-pdf] pdf viewer에 inline style을 주입할 수 있도록 props를 추가합니다

### DIFF
--- a/.changeset/shy-papayas-tease.md
+++ b/.changeset/shy-papayas-tease.md
@@ -1,0 +1,5 @@
+---
+"@naverpay/react-pdf": patch
+---
+
+[react-pdf] pdf viewer에 inline style을 주입할 수 있도록 props를 추가합니다

--- a/packages/react-pdf/src/components/PdfViewer.tsx
+++ b/packages/react-pdf/src/components/PdfViewer.tsx
@@ -1,4 +1,4 @@
-import {MouseEventHandler, ReactNode, useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {CSSProperties, MouseEventHandler, ReactNode, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 
 import classNames from 'classnames/bind'
 
@@ -36,6 +36,10 @@ export type PdfViewerProps = PdfRenderProps & {
      */
     header?: ReactNode
     footer?: ReactNode
+    /**
+     * pdf viewer 최상단 div style
+     */
+    style?: CSSProperties
 }
 
 export function PdfViewer({
@@ -49,6 +53,7 @@ export function PdfViewer({
     externalLinkTarget = '_blank',
     onLoadPDFRender,
     onErrorPDFRender,
+    style = {},
     ...options
 }: PdfViewerProps) {
     const [pdf, setPdf] = useState<PDFDocumentProxy | undefined>()
@@ -135,7 +140,7 @@ export function PdfViewer({
             tokenize={injectedTokenize ?? (onClickWords || []).length > 0}
             {...options}
         >
-            <div ref={ref} className={cx('article')} onClick={handleClickWords}>
+            <div ref={ref} style={style} className={cx('article')} onClick={handleClickWords}>
                 {header}
                 <Pages />
                 {footer}


### PR DESCRIPTION
## Related Issue <!-- #뒤에 이슈번호 작성 -->

- this close #94

## Describe your changes <!-- PR의 주요 작업 내용 작성 -->

- pdf viewer에 inline style을 주입할 수 있도록 props를 추가합니다
 
## Request <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->

-
