### PR TITLE
:bug: 누락된 withCredentials 옵션을 넘겨줍니다

### DIFF
--- a/.changeset/fluffy-spies-think.md
+++ b/.changeset/fluffy-spies-think.md
@@ -1,0 +1,5 @@
+---
+"@naverpay/react-pdf": patch
+---
+
+:bug: 누락된 withCredentials 옵션을 넘겨줍니다

--- a/packages/react-pdf/src/utils/pdf.ts
+++ b/packages/react-pdf/src/utils/pdf.ts
@@ -45,12 +45,14 @@ interface GetPdfDocumentParams {
     file: string | ArrayBuffer | Blob | File
     cMapUrl?: string | null
     cMapPacked?: boolean
+    withCredentials?: boolean
 }
 
 export async function getPdfDocument({
     file,
     cMapUrl = null,
     cMapPacked = false,
+    withCredentials = false,
 }: GetPdfDocumentParams): Promise<PDFDocumentProxy> {
     if (isSSR()) {
         throw new Error('client side에서 실행시켜 주세요.')
@@ -92,7 +94,11 @@ export async function getPdfDocument({
         source = {...source, cMapPacked}
     }
 
-    const {promise} = pdfjs.getDocument({...source, isEvalSupported: false}) as PDFLoadingTask<PDFDocumentProxy>
+    const {promise} = pdfjs.getDocument({
+        ...source,
+        isEvalSupported: false,
+        withCredentials,
+    }) as PDFLoadingTask<PDFDocumentProxy>
     const pdfInfo = await promise
     return pdfInfo
 }


### PR DESCRIPTION
## Related Issue <!-- #뒤에 이슈번호 작성 -->

- `withCredentials`을 넘겨주지 않던 문제를 수정합니다.