### PR TITLE
[rollup] preserve-directives 이 ESM 빌드 시에만 주입되도록 변경

### DIFF
--- a/.changeset/pink-items-fix.md
+++ b/.changeset/pink-items-fix.md
@@ -1,0 +1,5 @@
+---
+"@naverpay/rollup": patch
+---
+
+preserve-directives 플러그인이 ESM 빌드 시에만 주입되도록 변경

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -192,7 +192,7 @@ export function generateRollupConfig({
                 : []),
             ...(minify ? [terser()] : []),
             ...extraPlugins,
-            preserveDirectives(),
+            ...(isESM ? [preserveDirectives()] : []),
         ]
 
         return {


### PR DESCRIPTION
## Related Issue <!-- #뒤에 이슈번호 작성 -->

- close #100

## Describe your changes <!-- PR의 주요 작업 내용 작성 -->

- `preserve-directives` 플러그인이 CJS 빌드에도 주입이 되고 있어 ESM 빌드 시에만 주입되도록 변경합니다.

## Request <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->

-
