### PR TITLE
[react-pdf] canvas를 그리는 도중 canvas를 또 그려야되는 상황이 되면, 이전 동작을 취소하고 다시 그립니다.

### DIFF
--- a/.changeset/blue-hotels-tie.md
+++ b/.changeset/blue-hotels-tie.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/react-pdf": patch
+---
+
+
+
+[canvas를 그리는 도중 canvas를 또 그려야되는 상황이 되면, 이전 동작을 취소하고 다시 그립니다.](https://github.com/NaverPayDev/pie/pull/106)

--- a/packages/react-pdf/src/components/page/Canvas.tsx
+++ b/packages/react-pdf/src/components/page/Canvas.tsx
@@ -1,9 +1,11 @@
-import {memo, useCallback} from 'react'
+import {memo, useCallback, useRef} from 'react'
 
 import {usePdfPageContext} from '../../contexts/page'
+import {PDFRenderTask} from '../../pdfjs-dist/types/pdfjs'
 import {getPixelRatio} from '../../utils/pdf'
 
 export const PageCanvas = memo(function PageCanvas() {
+    const pageRenderTask = useRef<PDFRenderTask>()
     const {page, viewport: renderViewport, scale} = usePdfPageContext()
 
     const drawCanvas = useCallback(
@@ -18,6 +20,8 @@ export const PageCanvas = memo(function PageCanvas() {
                     return
                 }
 
+                pageRenderTask.current?.cancel()
+
                 const canvasViewport = page.getViewport({scale: scale * getPixelRatio()})
 
                 canvas.width = canvasViewport.width
@@ -26,7 +30,7 @@ export const PageCanvas = memo(function PageCanvas() {
                 canvas.style.width = `${Math.floor(renderViewport.width)}px`
                 canvas.style.height = `${Math.floor(renderViewport.height)}px`
 
-                page.render({canvasContext, viewport: canvasViewport})
+                pageRenderTask.current = page.render({canvasContext, viewport: canvasViewport})
             })
         },
         [page, renderViewport.height, renderViewport.width, scale],


### PR DESCRIPTION
## Related Issue <!-- #뒤에 이슈번호 작성 -->

- close #105

## Describe your changes <!-- PR의 주요 작업 내용 작성 -->

- canvas를 그리는 도중 canvas를 또 그려야되는 상황이 되면, 이전 동작을 취소하고 다시 그립니다.
- window width 변화로 pdf scale에 변화가 생기면 canvas를 다시 그리는 일이 생기는데, 이때 race condition에 의해 canvas context에서 충돌이 발생합니다.. 이를 제거합니다.

## Request <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->

-
