### PR TITLE
[vanilla-store] createVanillaSelect 구현

### DIFF
--- a/.changeset/fine-dancers-wash.md
+++ b/.changeset/fine-dancers-wash.md
@@ -1,0 +1,8 @@
+---
+"@naverpay/vanilla-store": minor
+---
+
+
+[vanilla-store] `createVanillaSelect` 추가
+
+[[vanilla-store] createVanillaSelect 구현](https://github.com/NaverPayDev/pie/pull/113)

--- a/packages/vanilla-store/src/applyOptions.ts
+++ b/packages/vanilla-store/src/applyOptions.ts
@@ -1,0 +1,23 @@
+import {LocalStoragePersist, SessionStoragePersist} from './persist'
+import {Persistent} from './persist/type'
+import {Options} from './type'
+
+export const applyPersist = <State>(options: Options<State> = {}, addCallbacks: () => void, initialState: State) => {
+    let persistStore: Persistent<State> | null = null
+
+    if (options?.persist) {
+        const key = options.persist.key
+
+        if (options.persist.type === 'localStorage') {
+            persistStore = new LocalStoragePersist(key, initialState, options.persist.typeAssertion)
+            addCallbacks()
+        }
+
+        if (options.persist.type === 'sessionStorage') {
+            persistStore = new SessionStoragePersist(key, initialState, options.persist.typeAssertion)
+            addCallbacks()
+        }
+    }
+
+    return persistStore
+}

--- a/packages/vanilla-store/src/index.ts
+++ b/packages/vanilla-store/src/index.ts
@@ -1,3 +1,4 @@
 export * from './store'
 export * from './react'
 export * from './persist'
+export * from './select'

--- a/packages/vanilla-store/src/persist/hooks.ts
+++ b/packages/vanilla-store/src/persist/hooks.ts
@@ -1,8 +1,8 @@
 import {useEffect} from 'react'
 
-import {VanillaStore} from '../store'
+import {VanillaStore, VanillaSelect} from '../type'
 
-export function useSyncPersistStore<State>(store: VanillaStore<State>, value: State) {
+export function useSyncPersistStore<State>(store: VanillaStore<State> | VanillaSelect<State>, value: State) {
     useEffect(() => {
         if (store.persistStore?.value !== value) {
             if (store.persistStore?.value) {

--- a/packages/vanilla-store/src/react.ts
+++ b/packages/vanilla-store/src/react.ts
@@ -2,23 +2,27 @@ import {useRef, useSyncExternalStore} from 'react'
 
 import {useSyncPersistStore} from './persist/hooks'
 import shallowEqual from './shallowEqual'
-import {VanillaStore} from './store'
+import {SetAction, VanillaSelect, VanillaStore} from './type'
 
-export const useStore = <State>(store: VanillaStore<State>, initialValue?: State) => {
+export function useStore<State>(store: VanillaSelect<State>, initialValue?: State): [State, never]
+export function useStore<State>(store: VanillaStore<State>, initialValue?: State): [State, SetAction<State>]
+export function useStore<State>(store: VanillaStore<State> | VanillaSelect<State>, initialValue?: State) {
     const value = useSyncExternalStore(store.subscribe, store.get, () => initialValue || store.get())
     useSyncPersistStore(store, value)
 
     return [value, store.set] as const
 }
 
-export const useGetStore = <State>(store: VanillaStore<State>, initialValue?: State) => {
+export const useGetStore = <State>(store: VanillaStore<State> | VanillaSelect<State>, initialValue?: State) => {
     const value = useSyncExternalStore(store.subscribe, store.get, () => initialValue || store.get())
     useSyncPersistStore(store, value)
 
     return value
 }
 
-export const useSetStore = <State>(store: VanillaStore<State>, initialValue?: State) => {
+export function useSetStore<State>(store: VanillaSelect<State>, initialValue?: State): never
+export function useSetStore<State>(store: VanillaStore<State>, initialValue?: State): SetAction<State>
+export function useSetStore<State>(store: VanillaStore<State> | VanillaSelect<State>, initialValue?: State) {
     const value = useSyncExternalStore(store.subscribe, store.get, () => initialValue || store.get())
     useSyncPersistStore(store, value)
 
@@ -45,11 +49,21 @@ export function useSyncExternalStoreWithSelector<Snapshot, Selection>(
     return stateRef.current
 }
 
-export const useStoreSelector = <State, Value>(
+export function useStoreSelector<State, Value>(
+    store: VanillaSelect<State>,
+    selector: (state: State) => Value,
+    options?: {initialStoreValue?: State; isEqual?: (a: Value, b: Value) => boolean},
+): [Value, never]
+export function useStoreSelector<State, Value>(
     store: VanillaStore<State>,
     selector: (state: State) => Value,
     options?: {initialStoreValue?: State; isEqual?: (a: Value, b: Value) => boolean},
-) => {
+): [Value, SetAction<State>]
+export function useStoreSelector<State, Value>(
+    store: VanillaStore<State> | VanillaSelect<State>,
+    selector: (state: State) => Value,
+    options?: {initialStoreValue?: State; isEqual?: (a: Value, b: Value) => boolean},
+) {
     const {initialStoreValue, isEqual} = options || {}
     const value = useSyncExternalStoreWithSelector(
         store.subscribe,
@@ -58,5 +72,5 @@ export const useStoreSelector = <State, Value>(
         selector,
         isEqual,
     )
-    return [value, store.set] as const
+    return [value, store.set]
 }

--- a/packages/vanilla-store/src/react.ts
+++ b/packages/vanilla-store/src/react.ts
@@ -4,18 +4,22 @@ import {useSyncPersistStore} from './persist/hooks'
 import shallowEqual from './shallowEqual'
 import {SetAction, VanillaSelect, VanillaStore} from './type'
 
+function useSyncStore<State>(store: VanillaStore<State> | VanillaSelect<State>, initialValue?: State) {
+    const value = useSyncExternalStore(store.subscribe, store.get, () => initialValue || store.get())
+    useSyncPersistStore(store, value)
+    return value
+}
+
 export function useStore<State>(store: VanillaSelect<State>, initialValue?: State): [State, never]
 export function useStore<State>(store: VanillaStore<State>, initialValue?: State): [State, SetAction<State>]
 export function useStore<State>(store: VanillaStore<State> | VanillaSelect<State>, initialValue?: State) {
-    const value = useSyncExternalStore(store.subscribe, store.get, () => initialValue || store.get())
-    useSyncPersistStore(store, value)
+    const value = useSyncStore(store, initialValue)
 
     return [value, store.set] as const
 }
 
 export const useGetStore = <State>(store: VanillaStore<State> | VanillaSelect<State>, initialValue?: State) => {
-    const value = useSyncExternalStore(store.subscribe, store.get, () => initialValue || store.get())
-    useSyncPersistStore(store, value)
+    const value = useSyncStore(store, initialValue)
 
     return value
 }
@@ -23,8 +27,7 @@ export const useGetStore = <State>(store: VanillaStore<State> | VanillaSelect<St
 export function useSetStore<State>(store: VanillaSelect<State>, initialValue?: State): never
 export function useSetStore<State>(store: VanillaStore<State>, initialValue?: State): SetAction<State>
 export function useSetStore<State>(store: VanillaStore<State> | VanillaSelect<State>, initialValue?: State) {
-    const value = useSyncExternalStore(store.subscribe, store.get, () => initialValue || store.get())
-    useSyncPersistStore(store, value)
+    useSyncStore(store, initialValue)
 
     return store.set
 }

--- a/packages/vanilla-store/src/select.test.ts
+++ b/packages/vanilla-store/src/select.test.ts
@@ -1,0 +1,36 @@
+import {createVanillaSelect} from './select'
+import {createVanillaStore} from './store'
+
+describe('Select', () => {
+    test('get result of selectFn', () => {
+        const sampleObject = {count: 0, name: 'hello'}
+        const store = createVanillaStore(sampleObject)
+        const select = createVanillaSelect(store, (st) => st.count)
+
+        expect(select.get()).toBe(0)
+    })
+
+    test('get result of selectFn after store.set()', () => {
+        const sampleObject = {count: 0, name: 'hello'}
+        const store = createVanillaStore(sampleObject)
+        const select = createVanillaSelect(store, (st) => st.count)
+
+        store.set((prev) => ({
+            ...prev,
+            count: prev.count + 1,
+        }))
+
+        expect(select.get()).toBe(1)
+    })
+
+    test('get result of selectFn with equalityFn()', () => {
+        const store = createVanillaStore('Naver Pay')
+        const select = createVanillaSelect(
+            store,
+            (str) => str.split(' '),
+            (a, b) => a.length === b.length && a.every((elem, idx) => elem === b[idx]),
+        )
+
+        expect(select.get()).toStrictEqual(['Naver', 'Pay'])
+    })
+})

--- a/packages/vanilla-store/src/select.ts
+++ b/packages/vanilla-store/src/select.ts
@@ -1,0 +1,37 @@
+import {applyPersist} from './applyOptions'
+import {Persistent} from './persist/type'
+import {Options, VanillaSelect, VanillaStore} from './type'
+
+export const createVanillaSelect = <State, StoreState>(
+    store: VanillaStore<StoreState>,
+    selectFn: (state: StoreState) => State,
+    options?: Options<State>,
+): VanillaSelect<State> => {
+    const callbacks = new Set<() => void>()
+
+    const get = () => selectFn(store.get())
+
+    let persistStore: Persistent<State> | null = null
+
+    const addCallbacks = () =>
+        callbacks.add(() => {
+            if (persistStore) {
+                persistStore.value = get()
+            }
+        })
+
+    persistStore = applyPersist(options, addCallbacks, selectFn(store.get()))
+
+    const subscribe = (callback: () => void) => {
+        callbacks.add(callback)
+        return () => {
+            callbacks.delete(callback)
+        }
+    }
+
+    const set = () => {
+        callbacks.forEach((callback) => callback())
+    }
+
+    return {get, set, subscribe, persistStore}
+}

--- a/packages/vanilla-store/src/select.ts
+++ b/packages/vanilla-store/src/select.ts
@@ -11,14 +11,7 @@ export const createVanillaSelect = <State, StoreState>(
 ): VanillaSelect<State> => {
     const callbacks = new Set<() => void>()
 
-    let state: State
-
-    let hasMemo: boolean = false
-
-    if (!hasMemo) {
-        hasMemo = true
-        state = selectFn(store.get())
-    }
+    let state: State = selectFn(store.get())
 
     const get = () => {
         const next = selectFn(store.get())

--- a/packages/vanilla-store/src/store.ts
+++ b/packages/vanilla-store/src/store.ts
@@ -1,13 +1,6 @@
 import {applyPersist} from './applyOptions'
 import {Persistent} from './persist/type'
-import {Options} from './type'
-
-export interface VanillaStore<State> {
-    get: () => State
-    set: (action: State | ((prev: State) => State)) => State
-    subscribe: (callback: () => void) => () => void
-    persistStore: Persistent<State> | null
-}
+import {Options, VanillaStore} from './type'
 
 export interface Subscription<Value> {
     getCurrentValue: () => Value

--- a/packages/vanilla-store/src/type.ts
+++ b/packages/vanilla-store/src/type.ts
@@ -1,4 +1,21 @@
+import {Persistent} from './persist/type'
+
 type PersistType = 'localStorage' | 'sessionStorage'
 export interface Options<State> {
     persist?: {type: PersistType; key: string; typeAssertion: (value: unknown) => value is State}
+}
+
+export interface Vanilla<State> {
+    get: () => State
+    subscribe: (callback: () => void) => () => void
+    persistStore: Persistent<State> | null
+}
+
+export type SetAction<State> = (action: State | ((prev: State) => State)) => State
+export interface VanillaStore<State> extends Vanilla<State> {
+    set: SetAction<State>
+}
+
+export interface VanillaSelect<State> extends Vanilla<State> {
+    set: () => void
 }

--- a/packages/vanilla-store/src/type.ts
+++ b/packages/vanilla-store/src/type.ts
@@ -1,0 +1,4 @@
+type PersistType = 'localStorage' | 'sessionStorage'
+export interface Options<State> {
+    persist?: {type: PersistType; key: string; typeAssertion: (value: unknown) => value is State}
+}

--- a/packages/vanilla-store/tsconfig.json
+++ b/packages/vanilla-store/tsconfig.json
@@ -3,10 +3,8 @@
     "compilerOptions": {
         "baseUrl": ".",
         "declarationDir": "./dist/cjs",
-        "experimentalDecorators": true,
-        "typeRoots": ["./node_modules/@types"],
-        "types": ["jest", "react"]
+        "experimentalDecorators": true
     },
-    "include": ["./src", "./typings"],
+    "include": ["./src"],
     "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Related Issue <!-- #뒤에 이슈번호 작성 -->

#112

## Describe your changes <!-- PR의 주요 작업 내용 작성 -->

- `creatVanillaSelect`를 구현합니다.
- useSetStore, useStore, useStoreSelector에 함수오버라이드를 적용하여 select의 set은 사용못하도록 합니다.

## Request <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->

- [x] 로컬 테스트 완료 (myasset-web)
