### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/fine-dancers-wash.md
+++ b/.changeset/fine-dancers-wash.md
@@ -1,8 +1,0 @@
----
-"@naverpay/vanilla-store": minor
----
-
-
-[vanilla-store] `createVanillaSelect` 추가
-
-[[vanilla-store] createVanillaSelect 구현](https://github.com/NaverPayDev/pie/pull/113)

--- a/packages/vanilla-store/CHANGELOG.md
+++ b/packages/vanilla-store/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @naverpay/vanilla-store
 
+## 0.1.0
+
+### Minor Changes
+
+-   cc45eb4: [vanilla-store] `createVanillaSelect` 추가
+
+    [[vanilla-store] createVanillaSelect 구현](https://github.com/NaverPayDev/pie/pull/113)
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/vanilla-store/package.json
+++ b/packages/vanilla-store/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/vanilla-store",
-    "version": "0.0.1",
+    "version": "0.1.0",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
     "exports": {


### PR DESCRIPTION
# Releases
## @naverpay/vanilla-store@0.1.0

### Minor Changes

-   cc45eb4: [vanilla-store] `createVanillaSelect` 추가

    [\[vanilla-store\] createVanillaSelect 구현](https://github.com/NaverPayDev/pie/pull/113)
