### PR TITLE
[react-pdf] pdfjs dist에 export default 가 없어 생기는 빌드 에러를 해결합니다

### DIFF
--- a/.changeset/social-moments-study.md
+++ b/.changeset/social-moments-study.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/react-pdf": patch
+---
+
+[react-pdf] pdfjs dist에 export default 가 없어 생기는 빌드 에러를 해결합니다
+
+PR: [[react-pdf] pdfjs dist에 export default 가 없어 생기는 빌드 에러를 해결합니다](https://github.com/NaverPayDev/pie/pull/139)

--- a/packages/react-pdf/src/utils/pdf.ts
+++ b/packages/react-pdf/src/utils/pdf.ts
@@ -1,4 +1,4 @@
-import pdfjs from 'pdfjs-dist'
+import {version, getDocument, GlobalWorkerOptions} from 'pdfjs-dist'
 
 import type {DocumentInitParameters} from 'pdfjs-dist/types/src/display/api'
 
@@ -94,8 +94,7 @@ export async function getPdfDocument({
     /**
      * 자체적으로 worker를 제공하지 않으면, 해당 버전의 pdf worker unpkg cdn을 사용합니다.
      */
-    pdfjs.GlobalWorkerOptions.workerSrc =
-        workerSource || `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`
+    GlobalWorkerOptions.workerSrc = workerSource || `//unpkg.com/pdfjs-dist@${version}/build/pdf.worker.min.mjs`
 
     const fileData = await getPdfFile(file)
 
@@ -106,7 +105,7 @@ export async function getPdfDocument({
         ...(cMapPacked ? {cMapPacked} : {}),
     }
 
-    const {promise} = pdfjs.getDocument(source)
+    const {promise} = getDocument(source)
     const pdfInfo = await promise
     return pdfInfo
 }


### PR DESCRIPTION
## Related Issue <!-- #뒤에 이슈번호 작성 -->

- this close #138

## Describe your changes <!-- PR의 주요 작업 내용 작성 -->

- pdfjs dist에 export default 가 없어 생기는 빌드 에러를 해결합니다

## Request <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->

-
