### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/social-moments-study.md
+++ b/.changeset/social-moments-study.md
@@ -1,7 +1,0 @@
----
-"@naverpay/react-pdf": patch
----
-
-[react-pdf] pdfjs dist에 export default 가 없어 생기는 빌드 에러를 해결합니다
-
-PR: [[react-pdf] pdfjs dist에 export default 가 없어 생기는 빌드 에러를 해결합니다](https://github.com/NaverPayDev/pie/pull/139)

--- a/packages/react-pdf/CHANGELOG.md
+++ b/packages/react-pdf/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @naverpay/react-pdf
 
+## 1.0.1
+
+### Patch Changes
+
+-   8bbd752: [react-pdf] pdfjs dist에 export default 가 없어 생기는 빌드 에러를 해결합니다
+
+    PR: [[react-pdf] pdfjs dist에 export default 가 없어 생기는 빌드 에러를 해결합니다](https://github.com/NaverPayDev/pie/pull/139)
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/react-pdf/package.json
+++ b/packages/react-pdf/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/react-pdf",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "repository": {
         "type": "git",
         "url": "https://github.com/NaverPayDev/pie/tree/main/packages/react-pdf"


### PR DESCRIPTION
# Releases
## @naverpay/react-pdf@1.0.1

### Patch Changes

-   8bbd752: [react-pdf] pdfjs dist에 export default 가 없어 생기는 빌드 에러를 해결합니다

    PR: [\[react-pdf\] pdfjs dist에 export default 가 없어 생기는 빌드 에러를 해결합니다](https://github.com/NaverPayDev/pie/pull/139)
