### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/hip-pears-add.md
+++ b/.changeset/hip-pears-add.md
@@ -1,7 +1,0 @@
----
-"@naverpay/react-pdf": patch
----
-
-`legacy build`를 사용하도록 변경
-
-PR: [pdf 개선 작업](https://github.com/NaverPayDev/pie/pull/142)

--- a/packages/react-pdf/CHANGELOG.md
+++ b/packages/react-pdf/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @naverpay/react-pdf
 
+## 1.0.2
+
+### Patch Changes
+
+-   51e853e: `legacy build`를 사용하도록 변경
+
+    PR: [pdf 개선 작업](https://github.com/NaverPayDev/pie/pull/142)
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/react-pdf/package.json
+++ b/packages/react-pdf/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/react-pdf",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "repository": {
         "type": "git",
         "url": "https://github.com/NaverPayDev/pie/tree/main/packages/react-pdf"


### PR DESCRIPTION
# Releases
## @naverpay/react-pdf@1.0.2

### Patch Changes

-   51e853e: `legacy build`를 사용하도록 변경

    PR: [pdf 개선 작업](https://github.com/NaverPayDev/pie/pull/142)
