### PR TITLE
✨ feat: add URL parsing polyfill to PdfViewer, AnnotationLayer, and pdf utilities

### DIFF
--- a/.changeset/shaggy-cities-taste.md
+++ b/.changeset/shaggy-cities-taste.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/react-pdf": patch
+---
+
+✨ feat: add URL parsing polyfill to PdfViewer, AnnotationLayer, and pdf utilities
+
+PR: [✨ feat: add URL parsing polyfill to PdfViewer, AnnotationLayer, and pdf utilities](https://github.com/NaverPayDev/pie/pull/144)

--- a/packages/react-pdf/package.json
+++ b/packages/react-pdf/package.json
@@ -42,7 +42,6 @@
     },
     "dependencies": {
         "classnames": "^2.5.1",
-        "core-js": "3.41.0",
         "pdfjs-dist": "^4.10.38"
     },
     "devDependencies": {

--- a/packages/react-pdf/src/components/PdfViewer.tsx
+++ b/packages/react-pdf/src/components/PdfViewer.tsx
@@ -1,4 +1,5 @@
 import 'core-js/features/promise/with-resolvers'
+import 'core-js/features/url/parse'
 
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 

--- a/packages/react-pdf/src/components/PdfViewer.tsx
+++ b/packages/react-pdf/src/components/PdfViewer.tsx
@@ -1,6 +1,3 @@
-import 'core-js/features/promise/with-resolvers'
-import 'core-js/features/url/parse'
-
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 
 import classNames from 'classnames/bind'

--- a/packages/react-pdf/src/components/layer/Annotation.tsx
+++ b/packages/react-pdf/src/components/layer/Annotation.tsx
@@ -1,6 +1,3 @@
-import 'core-js/features/promise/with-resolvers'
-import 'core-js/features/url/parse'
-
 import {memo, useCallback, useMemo, useState} from 'react'
 
 import classNames from 'classnames/bind'

--- a/packages/react-pdf/src/components/layer/Annotation.tsx
+++ b/packages/react-pdf/src/components/layer/Annotation.tsx
@@ -1,4 +1,5 @@
 import 'core-js/features/promise/with-resolvers'
+import 'core-js/features/url/parse'
 
 import {memo, useCallback, useMemo, useState} from 'react'
 

--- a/packages/react-pdf/src/components/layer/Annotation.tsx
+++ b/packages/react-pdf/src/components/layer/Annotation.tsx
@@ -4,7 +4,7 @@ import 'core-js/features/url/parse'
 import {memo, useCallback, useMemo, useState} from 'react'
 
 import classNames from 'classnames/bind'
-import {AnnotationLayer as PdfAnnotationLayer} from 'pdfjs-dist'
+import {AnnotationLayer as PdfAnnotationLayer} from 'pdfjs-dist/legacy/build/pdf.mjs'
 
 import styles from './Annotation.module.scss'
 import {usePdfPageContext} from '../../contexts/page'

--- a/packages/react-pdf/src/utils/pdf.ts
+++ b/packages/react-pdf/src/utils/pdf.ts
@@ -1,4 +1,5 @@
 import 'core-js/features/promise/with-resolvers'
+import 'core-js/features/url/parse'
 
 import {getDocument, GlobalWorkerOptions, version} from 'pdfjs-dist'
 

--- a/packages/react-pdf/src/utils/pdf.ts
+++ b/packages/react-pdf/src/utils/pdf.ts
@@ -1,7 +1,7 @@
 import 'core-js/features/promise/with-resolvers'
 import 'core-js/features/url/parse'
 
-import {getDocument, GlobalWorkerOptions, version} from 'pdfjs-dist'
+import {getDocument, GlobalWorkerOptions, version} from 'pdfjs-dist/legacy/build/pdf.mjs'
 
 import type {DocumentInitParameters} from 'pdfjs-dist/types/src/display/api'
 

--- a/packages/react-pdf/src/utils/pdf.ts
+++ b/packages/react-pdf/src/utils/pdf.ts
@@ -1,6 +1,3 @@
-import 'core-js/features/promise/with-resolvers'
-import 'core-js/features/url/parse'
-
 import {getDocument, GlobalWorkerOptions, version} from 'pdfjs-dist/legacy/build/pdf.mjs'
 
 import type {DocumentInitParameters} from 'pdfjs-dist/types/src/display/api'
@@ -94,7 +91,7 @@ export async function getPdfDocument({
         throw new Error('client side에서 실행시켜 주세요.')
     }
 
-    GlobalWorkerOptions.workerSrc = workerSource || `//unpkg.com/pdfjs-dist@${version}/build/pdf.worker.min.mjs`
+    GlobalWorkerOptions.workerSrc = workerSource || `//unpkg.com/pdfjs-dist@${version}/legacy/build/pdf.worker.min.mjs`
 
     const fileData = await getPdfFile(file)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,9 +187,6 @@ importers:
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
-      core-js:
-        specifier: 3.41.0
-        version: 3.41.0
       pdfjs-dist:
         specifier: ^4.10.38
         version: 4.10.38


### PR DESCRIPTION
## 문제 원인

- 하필 크롬 114 만 Promise.withResolvers 가 삐꾸임 (젠장)
- pdfjs dist 는 정말 latest 브라우저만 타겟으로 함
- 절 대 legacy  만 사용할 것 (폴리필 기본 포함되어 있음) 진짜 쓰지마라 @2-one-week 