### PR TITLE
Add a canary publish github action

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -40,3 +40,4 @@ jobs:
                   publish_script: pnpm run release:canary # Script to execute Canary deployment
                   packages_dir: packages # Directory of packages to detect changes (default: packages,share)
                   excludes: '.turbo,.github' # Files or directories to exclude from change detection
+                  version_template: '{VERSION}-canary.{DATE}-{COMMITID7}'

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,5 +1,5 @@
 # Adjust according to your needs
-name: changeset canary publish
+name: Release Canary
 
 on:
     issue_comment:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,42 @@
+# Adjust according to your needs
+name: changeset canary publish
+
+on:
+    issue_comment:
+        types:
+            - created
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+    canary:
+        if: ${{ github.event.issue.pull_request && (github.event.comment.body == 'canary-publish' || github.event.comment.body == '/canary-publish')}}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Get PR branch name
+              id: get_branch
+              run: |
+                  PR=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" ${{ github.event.issue.pull_request.url }})
+                  echo "::set-output name=branch::$(echo $PR | jq -r '.head.ref')"
+
+            - uses: actions/checkout@v4
+              with:
+                  ref: ${{ steps.get_branch.outputs.branch }}
+            - uses: pnpm/action-setup@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '22'
+                  cache: 'pnpm'
+
+            - name: Install Dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Canary Publish
+              uses: NaverPayDev/changeset-actions/canary-publish@main
+              with:
+                  github_token: ${{ secrets.ACTION_TOKEN }} # Add user PAT if necessary
+                  npm_tag: canary # Specify the npm tag to use for deployment
+                  npm_token: ${{ secrets.NPM_TOKEN }} # Provide the token required for npm publishing
+                  publish_script: pnpm run release:canary # Script to execute Canary deployment
+                  packages_dir: packages # Directory of packages to detect changes (default: packages,share)
+                  excludes: '.turbo,.github' # Files or directories to exclude from change detection


### PR DESCRIPTION
## Related Issue <!-- #뒤에 이슈번호 작성 -->

- #152

## Describe your changes <!-- PR의 주요 작업 내용 작성 -->

This PR adds a **Canary Publish GitHub Action** to the repository, based on the [`NaverPayDev/changeset-actions/canary-publish`](https://github.com/NaverPayDev/changeset-actions) action.

- Enables automated publishing of canary releases to npm when user add a `/canary-publish` comment.
- Uses a dedicated workflow file to handle canary deployments.
- Supports configurable options such as npm tag, token, publish script, and directory exclusions.


## Request <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->

- ⚠️ **Make sure that `secrets.NPM_TOKEN` is kept confidential and is only used in workflows running on the `main` branch. Always protect the token’s permissions carefully.**

## Next

- Add a `rc-publish` action with release tag.
