### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/afraid-hairs-float.md
+++ b/.changeset/afraid-hairs-float.md
@@ -1,8 +1,0 @@
----
-"@naverpay/es-http-status-codes": major
-"@naverpay/svg-manager": major
-"@naverpay/utils": major
----
-
-1.0.0 버전을 출시합니다. (변경사항은 없는 메이저버전 출시)
-

--- a/packages/es-http-status-codes/CHANGELOG.md
+++ b/packages/es-http-status-codes/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @naverpay/es-http-status-codes
 
+## 1.0.0
+
+### Major Changes
+
+-   d02d12a: 1.0.0 버전을 출시합니다. (변경사항은 없는 메이저버전 출시)
+
 ## 0.0.4
 
 ### Patch Changes

--- a/packages/es-http-status-codes/package.json
+++ b/packages/es-http-status-codes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/es-http-status-codes",
-    "version": "0.0.4",
+    "version": "1.0.0",
     "repository": {
         "type": "git",
         "url": "https://github.com/NaverPayDev/pie/tree/main/packages/es-http-status-codes"

--- a/packages/svg-manager/CHANGELOG.md
+++ b/packages/svg-manager/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @naverpay/svg-manager
 
+## 1.0.0
+
+### Major Changes
+
+-   d02d12a: 1.0.0 버전을 출시합니다. (변경사항은 없는 메이저버전 출시)
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/svg-manager/package.json
+++ b/packages/svg-manager/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/svg-manager",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "repository": {
         "type": "git",
         "url": "https://github.com/NaverPayDev/pie/tree/main/packages/svg-manager"

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @naverpay/utils
 
+## 1.0.0
+
+### Major Changes
+
+-   d02d12a: 1.0.0 버전을 출시합니다. (변경사항은 없는 메이저버전 출시)
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@naverpay/utils",
     "description": "javascript utility library",
-    "version": "0.3.1",
+    "version": "1.0.0",
     "repository": {
         "type": "git",
         "url": "https://github.com/NaverPayDev/pie/tree/main/packages/utils"


### PR DESCRIPTION
# Releases
## @naverpay/es-http-status-codes@1.0.0

### Major Changes

-   d02d12a: 1.0.0 버전을 출시합니다. (변경사항은 없는 메이저버전 출시)

## @naverpay/svg-manager@1.0.0

### Major Changes

-   d02d12a: 1.0.0 버전을 출시합니다. (변경사항은 없는 메이저버전 출시)

## @naverpay/utils@1.0.0

### Major Changes

-   d02d12a: 1.0.0 버전을 출시합니다. (변경사항은 없는 메이저버전 출시)
