### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/hot-nails-wear.md
+++ b/.changeset/hot-nails-wear.md
@@ -1,7 +1,0 @@
----
-"@naverpay/vanilla-store": patch
----
-
-✨ export PersistType for better accessibility in type definitions
-
-PR: [✨ export PersistType for better accessibility in type definitions](https://github.com/NaverPayDev/pie/pull/164)

--- a/packages/vanilla-store/CHANGELOG.md
+++ b/packages/vanilla-store/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @naverpay/vanilla-store
 
+## 1.1.1
+
+### Patch Changes
+
+-   c442c82: ✨ export PersistType for better accessibility in type definitions
+
+    PR: [✨ export PersistType for better accessibility in type definitions](https://github.com/NaverPayDev/pie/pull/164)
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/vanilla-store/package.json
+++ b/packages/vanilla-store/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/vanilla-store",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "repository": {
         "type": "git",
         "url": "https://github.com/NaverPayDev/pie/tree/main/packages/vanilla-store"


### PR DESCRIPTION
# Releases
## @naverpay/vanilla-store@1.1.1

### Patch Changes

-   c442c82: ✨ export PersistType for better accessibility in type definitions

    PR: [✨ export PersistType for better accessibility in type definitions](https://github.com/NaverPayDev/pie/pull/164)
