### PR TITLE
[url-param-compressor] 압축/압축 해제 실패시 처리, 압축 옵션 추가, 패키지명 수정

### DIFF
--- a/packages/url-param-compressor/package.json
+++ b/packages/url-param-compressor/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "url-param-compressor",
+    "name": "@naverpay/url-param-compressor",
     "version": "0.0.1",
     "repository": {
         "type": "git",

--- a/packages/url-param-compressor/src/URLParamCompressor.test.ts
+++ b/packages/url-param-compressor/src/URLParamCompressor.test.ts
@@ -10,16 +10,12 @@ describe('Test with long url', () => {
         surl: 'https%3A%2F%2Forders.pay.naver.com%2Fordersheet%2Fseller%2Ffds%2Fauth%2FkeypadFail%3Faction%3DREPLACE%26rurl%3Dhttps%3A%2F%2Forders.pay.naver.com%2Fordersheet%2Fseller%2Fapply%2Fshopn%2F2025031282074571%2F2025031282074571%26surl%3Dhttps%3A%2F%2Forders.pay.naver.com%2Fordersheet%2Fseller%2F443c0630-0505-1a01-d19c-d058401cefc8%3FbackUrl%3Dhttps%253A%252F%252Fproduct.shoppinglive.naver.com%252Fproducts%252F11364953053%253FNaPm%253Dct%25253Dm85vd8dp%25257Cci%25253Dshopn%25257Ctr%25253Dlim5%25257Chk%25253D489dc88bc28518bc226b9042238b545b141afd74%25257Ctrx%25253D1574969_1%2526nt_source%253Dnshoplive%2526nt_medium%253D1574969%2526nt_detail%253Donair%2526nt_keyword%253Dshoppinglive%2526prdFrom%253Db_1574969%2526extras%253D%25257B%252522entryInfo%252522%25253A%25257B%252522sourceId%252522%25253A%2525221574969%252522%25252C%252522sourceType%252522%25253A%252522BROADCAST%252522%25252C%252522externalId%252522%25253A%252522shoppinglive%252522%25252C%252522externalServiceType%252522%25253A%252522NAVER%252522%25252C%252522tr%252522%25253A%252522lim5%252522%25252C%252522trx%252522%25253A%2525221574969_1%252522%25252C%252522fm%252522%25253Anull%25252C%252522sn%252522%25253Anull%25252C%252522ea%252522%25253Anull%25252C%252522returnParams%252522%25253A%252522%25257B%25257D%252522%25252C%252522slAccountType%252522%25253A%252522NAVER%252522%25252C%252522slAccountId%252522%25253A%252522d7reO%252522%25252C%252522commissionType%252522%25253Anull%25252C%252522thirdPartyInfoAgreementType%252522%25253Anull%25257D%25257D%2526header%253Dfalse%26nl-au%3D72b8fa00d4844155bd16c5682f869759',
     }
 
-    let compressed = ''
-
-    beforeAll(() => {
-        compressed = compressor.compress(redirectUrls)
-    })
-
     test('원본 url로 복원한다.', () => {
-        const originalUrl = compressor.decompress(compressed)
+        const {result, isCompressed} = compressor.compress(redirectUrls)
+        const originalUrl = compressor.decompress(result)
 
         expect(originalUrl).toEqual(redirectUrls)
+        expect(isCompressed).toBe(true)
     })
 })
 
@@ -29,9 +25,10 @@ describe('Test with short url', () => {
             rurl: 'https%3A%2F%2Fnaver.com',
         }
 
-        const compressed = compressor.compress(redirectUrls)
+        const {result, isCompressed} = compressor.compress(redirectUrls)
 
-        expect(compressed).toBe(new URLSearchParams(redirectUrls).toString())
+        expect(result).toBe(new URLSearchParams(redirectUrls).toString())
+        expect(isCompressed).toBe(false)
     })
 })
 
@@ -51,7 +48,8 @@ describe('Get specific param', () => {
 
     let compressed = ''
     beforeAll(() => {
-        compressed = compressor.compress(redirectUrls)
+        const {result} = compressor.compress(redirectUrls)
+        compressed = result
     })
 
     test('특정 key를 정확하게 가져온다.', () => {
@@ -63,7 +61,7 @@ describe('Get specific param', () => {
             surl: 'https%253A%252F%252Forders.pay.naver.com%252Fordersheet%252Fseller%252Ffds%252Fauth%252FkeypadFail%253Faction%253DREPLACE%2526rurl%253Dhttps%253A%252F%252Forders.pay.naver.com%252Fordersheet%252Fseller%252Fapply%252Fshopn%252F2025031282074571%252F2025031282074571%2526surl%253Dhttps%253A%252F%252Forders.pay.naver.com%252Fordersheet%252Fseller%252F443c0630-0505-1a01-d19c-d058401cefc8%253FbackUrl%253Dhttps%25253A%25252F%25252Fproduct.shoppinglive.naver.com%25252Fproducts%25252F11364953053%25253FNaPm%25253Dct%2525253Dm85vd8dp%2525257Cci%2525253Dshopn%2525257Ctr%2525253Dlim5%2525257Chk%2525253D489dc88bc28518bc226b9042238b545b141afd74%2525257Ctrx%2525253D1574969_1%252526nt_source%25253Dnshoplive%252526nt_medium%25253D1574969%252526nt_detail%25253Donair%252526nt_keyword%25253Dshoppinglive%252526prdFrom%25253Db_1574969%252526extras%25253D%2525257B%25252522entryInfo%25252522%2525253A%2525257B%25252522sourceId%25252522%2525253A%252525221574969%25252522%2525252C%25252522sourceType%25252522%2525253A%25252522BROADCAST%25252522%2525252C%25252522externalId%25252522%2525253A%25252522shoppinglive%25252522%2525252C%25252522externalServiceType%25252522%2525253A%25252522NAVER%25252522%2525252C%25252522tr%25252522%2525253A%25252522lim5%25252522%2525252C%25252522trx%25252522%2525253A%252525221574969_1%25252522%2525252C%25252522fm%25252522%2525253Anull%2525252C%25252522sn%25252522%2525253Anull%2525252C%25252522ea%25252522%2525253Anull%2525252C%25252522returnParams%25252522%2525253A%25252522%2525257B%2525257D%25252522%2525252C%25252522slAccountType%25252522%2525253A%25252522NAVER%25252522%2525252C%25252522slAccountId%25252522%2525253A%25252522d7reO%25252522%2525252C%25252522commissionType%25252522%2525253Anull%2525252C%25252522thirdPartyInfoAgreementType%25252522%2525253Anull%2525257D%2525257D%252526header%25253Dfalse%2526nl-au%253D72b8fa00d4844155bd16c5682f869759',
         }
 
-        const compressed2 = compressor.compress(redirectUrls2)
+        const {result: compressed2} = compressor.compress(redirectUrls2)
         const result2 = compressor.get(compressed2, 'surl')
         expect(result2).toBe(redirectUrls.surl)
     })

--- a/packages/url-param-compressor/src/URLParamCompressor.test.ts
+++ b/packages/url-param-compressor/src/URLParamCompressor.test.ts
@@ -36,7 +36,7 @@ describe('Invalid data', () => {
     test('유효하지 않은 데이터라면 빈 객체를 반환한다.', () => {
         const result = compressor.decompress('abcdefg')
 
-        expect(result).toEqual({})
+        expect(result).toEqual(null)
     })
 })
 

--- a/packages/url-param-compressor/src/URLParamCompressor.test.ts
+++ b/packages/url-param-compressor/src/URLParamCompressor.test.ts
@@ -87,8 +87,13 @@ describe('URLParamCompressor 페이지 네비게이션 시나리오', () => {
                 rurl: 'https://example.com',
                 surl: 'https://example.com',
             }
-            const step2Compressed = compressor.compress(step2Data)
+            const {result: step2Compressed} = compressor.compress(step2Data)
             const step2Restored = compressor.decompress(step2Compressed)
+
+            expect(step2Restored).not.toBe(null)
+            if (step2Restored === null) {
+                return
+            }
 
             expect(step2Restored.rurl).toBe('https://example.com')
             expect(step2Restored.surl).toBe('https://example.com')
@@ -100,8 +105,13 @@ describe('URLParamCompressor 페이지 네비게이션 시나리오', () => {
                 rurl: step2FullUrl,
                 surl: step2FullUrl,
             }
-            const step3Compressed = compressor.compress(step3Data)
+            const {result: step3Compressed} = compressor.compress(step3Data)
             const step3Restored = compressor.decompress(step3Compressed)
+
+            expect(step3Restored).not.toBe(null)
+            if (step3Restored === null) {
+                return
+            }
 
             expect(step3Restored.rurl).toBe(step2FullUrl)
             expect(step3Restored.surl).toBe(step2FullUrl)
@@ -113,8 +123,13 @@ describe('URLParamCompressor 페이지 네비게이션 시나리오', () => {
                 rurl: step3FullUrl,
                 surl: step3FullUrl,
             }
-            const step4Compressed = compressor.compress(step4Data)
+            const {result: step4Compressed} = compressor.compress(step4Data)
             const step4Restored = compressor.decompress(step4Compressed)
+
+            expect(step4Restored).not.toBe(null)
+            if (step4Restored === null) {
+                return
+            }
 
             expect(step4Restored.rurl).toBe(step3FullUrl)
             expect(step4Restored.surl).toBe(step3FullUrl)
@@ -135,7 +150,7 @@ describe('URLParamCompressor 페이지 네비게이션 시나리오', () => {
                 searchHistory: JSON.stringify(['laptop', 'macbook', 'apple computer']),
             }
 
-            const compressed = compressor.compress(complexData)
+            const {result: compressed} = compressor.compress(complexData)
             const restored = compressor.decompress(compressed)
 
             expect(restored).toEqual(complexData)
@@ -146,17 +161,29 @@ describe('URLParamCompressor 페이지 네비게이션 시나리오', () => {
             const originalPage = 'https://example.com'
 
             const step2Data = {rurl: originalPage, surl: originalPage}
-            const step2Compressed = compressor.compress(step2Data)
+            const {result: step2Compressed} = compressor.compress(step2Data)
 
             const step2Restored = compressor.decompress(step2Compressed)
+
+            expect(step2Restored).not.toBe(null)
+            if (step2Restored === null) {
+                return
+            }
+
             const step2FullUrl = `https://example.com/next1?rurl=${encodeURIComponent(
                 step2Restored.rurl!,
             )}&surl=${encodeURIComponent(step2Restored.surl!)}`
             const step3Data = {rurl: step2FullUrl, surl: step2FullUrl}
-            const step3Compressed = compressor.compress(step3Data)
+            const {result: step3Compressed} = compressor.compress(step3Data)
 
             // step3에서 이전 페이지 정보 추출
             const step3Restored = compressor.decompress(step3Compressed)
+
+            expect(step3Restored).not.toBe(null)
+            if (step3Restored === null) {
+                return
+            }
+
             const step2Params = new URLSearchParams(step3Restored.rurl!.split('?')[1])
 
             expect(step2Params.get('rurl')).toBe(originalPage)

--- a/packages/url-param-compressor/src/URLParamCompressor.ts
+++ b/packages/url-param-compressor/src/URLParamCompressor.ts
@@ -2,13 +2,22 @@ import {deflateSync, inflateSync} from 'fflate'
 
 import LRUCache from './utils/LRUCache'
 
+import type {DeflateOptions} from 'fflate'
+
 export class URLParamCompressor {
     private paramsMap: LRUCache<Map<string, string>>
     private debug: boolean
+    private deflateOptions: DeflateOptions
 
-    constructor(options?: {debug?: boolean}) {
+    constructor(options?: {debug?: boolean; deflateOptions?: DeflateOptions}) {
         this.paramsMap = new LRUCache(100)
         this.debug = !!options?.debug
+
+        this.deflateOptions = {
+            level: options?.deflateOptions?.level ?? 6,
+            mem: options?.deflateOptions?.mem,
+            dictionary: options?.deflateOptions?.dictionary,
+        }
     }
 
     private stringToUint8Array(value: string) {
@@ -55,7 +64,7 @@ export class URLParamCompressor {
 
     compress(urlObj: Record<string, string>) {
         const param = new URLSearchParams(urlObj).toString()
-        const compressed = this.uint8ArrayToBase64URL(deflateSync(this.stringToUint8Array(param)))
+        const compressed = this.uint8ArrayToBase64URL(deflateSync(this.stringToUint8Array(param), this.deflateOptions))
         const paramLen = param.length
         const compressedLen = compressed.length
 
@@ -76,7 +85,9 @@ export class URLParamCompressor {
 
     decompress(compressedParams: string) {
         try {
-            const decompressed = this.uint8ArrayToString(inflateSync(this.base64URLToUint8Array(compressedParams)))
+            const decompressed = this.uint8ArrayToString(
+                inflateSync(this.base64URLToUint8Array(compressedParams), {dictionary: this.deflateOptions.dictionary}),
+            )
 
             const decompressedParams = new URLSearchParams(decompressed)
 

--- a/packages/url-param-compressor/src/URLParamCompressor.ts
+++ b/packages/url-param-compressor/src/URLParamCompressor.ts
@@ -69,7 +69,9 @@ export class URLParamCompressor {
             }
         }
 
-        return paramLen <= compressedLen ? param : compressed
+        const result = paramLen <= compressedLen ? param : compressed
+        const isCompressed = paramLen > compressedLen
+        return {result, isCompressed}
     }
 
     decompress(compressedParams: string) {

--- a/packages/url-param-compressor/src/URLParamCompressor.ts
+++ b/packages/url-param-compressor/src/URLParamCompressor.ts
@@ -89,7 +89,7 @@ export class URLParamCompressor {
 
             return result
         } catch {
-            return {}
+            return null
         }
     }
 


### PR DESCRIPTION
## Related Issue <!-- #뒤에 이슈번호 작성 -->

- #166 

## Describe your changes <!-- PR의 주요 작업 내용 작성 -->

- compress 메서드의 응답 형태를 수정했습니다. 압축이 되었는지 여부를 나타내는 `isCompressed`를 리턴합니다.
- 압축 해제를 실패했다면 null을 리턴해서 사용자가 확인할 수 있도록 했습니다.
- deflateOptions를 추가했습니다.
  - level: 테스트 해봤는데 최대로 올려도 별로 효과가 없습니다. 원래 default 값인 6을 기본으로 사용합니다.
  - mem: input data의 사이즈에 따라 자동으로 결정됩니다.
  - dictionary: 중복되는 문자열을 지정해서 압축률을 높일 수 있습니다.

## Request <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->

- level과 dictionary 필드 테스트를 해 보았는데, 효과가 거의 없었습니다. (dictionary는 %2f, %3d, naver, com 등등 테스트 해보았습니다.)
- gpt 왈
  - URL 파라미터가 매우 복잡하고 중첩된 URL을 이중~삼중 인코딩 상태로 포함하고 있습니다.
  - 인코딩된 문자열(%25, %2F, %3A 등)이 많지만, 이 인코딩 문자들이 중복 패턴보다는 다양하게 분포되어 있어 압축이 어려움.
  - 예를 들어, %25 다음에 나오는 숫자, 영문자가 매번 달라서 반복 패턴이 약함.
- 따라서 반복 패턴에 의한 압축 최적화는 효과가 미미할 것 같습니다.