### PR TITLE
[vanilla-store] Use persistValue as a priority in `VanillaSelect.get`

### DIFF
--- a/.changeset/khaki-shirts-divide.md
+++ b/.changeset/khaki-shirts-divide.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/vanilla-store": patch
+---
+
+[vanilla-store] Use persistValue as a priority in `VanillaSelect.get`
+
+PR: [[vanilla-store] Use persistValue as a priority in `VanillaSelect.get`](https://github.com/NaverPayDev/pie/pull/188)

--- a/packages/vanilla-store/src/select.ts
+++ b/packages/vanilla-store/src/select.ts
@@ -15,7 +15,10 @@ export const createVanillaSelect = <State, StoreState>(
     let state: State = selectFn(store.get())
 
     const get = () => {
-        const next = selectFn(store.get())
+        const persistValue = store.persistStore?.value
+        const currentValue = persistValue && !shallowEqual(persistValue, store.get()) ? persistValue : store.get()
+
+        const next = selectFn(currentValue)
 
         if (!equalityFn(next, state)) {
             state = next


### PR DESCRIPTION
## Related Issue <!-- #뒤에 이슈번호 작성 -->

- #187 

## Describe your changes <!-- PR의 주요 작업 내용 작성 -->

- Fix a bug in `VanillaSelect`: Can not get right value when original store has a value in persistent storage.

## Request <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->

-
