### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/khaki-shirts-divide.md
+++ b/.changeset/khaki-shirts-divide.md
@@ -1,7 +1,0 @@
----
-"@naverpay/vanilla-store": patch
----
-
-[vanilla-store] Use persistValue as a priority in `VanillaSelect.get`
-
-PR: [[vanilla-store] Use persistValue as a priority in `VanillaSelect.get`](https://github.com/NaverPayDev/pie/pull/188)

--- a/packages/vanilla-store/CHANGELOG.md
+++ b/packages/vanilla-store/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @naverpay/vanilla-store
 
+## 1.1.3
+
+### Patch Changes
+
+-   87fc79d: [vanilla-store] Use persistValue as a priority in `VanillaSelect.get`
+
+    PR: [[vanilla-store] Use persistValue as a priority in `VanillaSelect.get`](https://github.com/NaverPayDev/pie/pull/188)
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/vanilla-store/package.json
+++ b/packages/vanilla-store/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/vanilla-store",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "repository": {
         "type": "git",
         "url": "https://github.com/NaverPayDev/pie/tree/main/packages/vanilla-store"


### PR DESCRIPTION
# Releases
## @naverpay/vanilla-store@1.1.3

### Patch Changes

-   87fc79d: [vanilla-store] Use persistValue as a priority in `VanillaSelect.get`

    PR: [\[vanilla-store\] Use persistValue as a priority in `VanillaSelect.get`](https://github.com/NaverPayDev/pie/pull/188)
