### PR TITLE
[#196] fix: 제거된 @naverpay/rollup 관련 흔적 정리

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,6 @@
 pie 는 아래와 같은 패키지를 제공하고 있습니다.
 
 - [@naverpay/react-pdf](https://github.com/NaverPayDev/pie/tree/main/packages/react-pdf) : 한글에 적합한 PDF 뷰어를 제공합니다.
-- [@naverpay/rollup](https://github.com/NaverPayDev/pie/tree/main/packages/rollup) : 쉽게 패키지 번들러를 생성할 수 있습니다.
 
 ## 버전 릴리즈
 

--- a/packages/es-http-status-codes/rollup.config.js
+++ b/packages/es-http-status-codes/rollup.config.js
@@ -1,8 +1,0 @@
-import {generateRollupConfig} from '@naverpay/rollup'
-
-module.exports = generateRollupConfig({
-    packageDir: __dirname,
-    entrypoint: './src/index.ts',
-    minify: false,
-    react: {runtime: 'automatic'},
-})


### PR DESCRIPTION
## Summary
- CONTRIBUTING.md에서 @naverpay/rollup 패키지 설명 제거
- es-http-status-codes/rollup.config.js 불필요한 파일 삭제

Closes #196