### PR TITLE
[#119] fix: docs URL에서 중복된 /docs/docs 경로 수정

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -12,7 +12,7 @@ const config: Config = {
     url: 'https://naverpaydev.github.io/',
     // Set the /<baseUrl>/ pathname under which your site is served
     // For GitHub pages deployment, it is often '/<projectName>/'
-    baseUrl: '/pie/docs/',
+    baseUrl: '/pie/',
 
     // GitHub pages deployment config.
     // If you aren't using GitHub pages, you don't need these.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bugs": {
         "url": "https://github.com/NaverPayDev/pie/issues"
     },
-    "homepage": "https://naverpaydev.github.io/pie/docs/",
+    "homepage": "https://naverpaydev.github.io/pie/",
     "description": "common packages of naver financial fe",
     "version": "0.0.0",
     "scripts": {

--- a/packages/es-http-status-codes/package.json
+++ b/packages/es-http-status-codes/package.json
@@ -8,7 +8,7 @@
     "bugs": {
         "url": "https://github.com/NaverPayDev/pie/issues"
     },
-    "homepage": "https://naverpaydev.github.io/pie/docs/docs/@naverpay/es-http-status-codes/",
+    "homepage": "https://naverpaydev.github.io/pie/docs/@naverpay/es-http-status-codes/",
     "sideEffects": false,
     "description": "A lightweight, tree-shakable utility for HTTP status codes and reason phrases in TypeScript/JavaScript. Auto-generated and ESM-compatible.",
     "keywords": [

--- a/packages/react-pdf/package.json
+++ b/packages/react-pdf/package.json
@@ -8,7 +8,7 @@
     "bugs": {
         "url": "https://github.com/NaverPayDev/pie/issues"
     },
-    "homepage": "https://naverpaydev.github.io/pie/docs/docs/@naverpay/react-pdf/",
+    "homepage": "https://naverpaydev.github.io/pie/docs/@naverpay/react-pdf/",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
     "types": "./dist/cjs/index.d.ts",

--- a/packages/safe-html-react-parser/package.json
+++ b/packages/safe-html-react-parser/package.json
@@ -73,5 +73,5 @@
         "dist"
     ],
     "sideEffects": false,
-    "homepage": "https://naverpaydev.github.io/pie/docs/docs/@naverpay/safe-html-react-parser/"
+    "homepage": "https://naverpaydev.github.io/pie/docs/@naverpay/safe-html-react-parser/"
 }

--- a/packages/svg-manager/package.json
+++ b/packages/svg-manager/package.json
@@ -8,7 +8,7 @@
     "bugs": {
         "url": "https://github.com/NaverPayDev/pie/issues"
     },
-    "homepage": "https://naverpaydev.github.io/pie/docs/docs/@naverpay/svg-manager/",
+    "homepage": "https://naverpaydev.github.io/pie/docs/@naverpay/svg-manager/",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
     "types": "./dist/cjs/index.d.ts",

--- a/packages/url-param-compressor/package.json
+++ b/packages/url-param-compressor/package.json
@@ -8,7 +8,7 @@
     "bugs": {
         "url": "https://github.com/NaverPayDev/pie/issues"
     },
-    "homepage": "https://naverpaydev.github.io/pie/docs/docs/@naverpay/url-param-compressor/",
+    "homepage": "https://naverpaydev.github.io/pie/docs/@naverpay/url-param-compressor/",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
     "types": "./dist/cjs/index.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,7 +9,7 @@
     "bugs": {
         "url": "https://github.com/NaverPayDev/pie/issues"
     },
-    "homepage": "https://naverpaydev.github.io/pie/docs/docs/@naverpay/utils/",
+    "homepage": "https://naverpaydev.github.io/pie/docs/@naverpay/utils/",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
     "types": "./dist/cjs/index.d.ts",

--- a/packages/vanilla-store/package.json
+++ b/packages/vanilla-store/package.json
@@ -8,7 +8,7 @@
     "bugs": {
         "url": "https://github.com/NaverPayDev/pie/issues"
     },
-    "homepage": "https://naverpaydev.github.io/pie/docs/docs/@naverpay/vanilla-store/",
+    "homepage": "https://naverpaydev.github.io/pie/docs/@naverpay/vanilla-store/",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
     "types": "./dist/cjs/index.d.ts",


### PR DESCRIPTION
## Summary
- docusaurus baseUrl을 `/pie/docs/`에서 `/pie/`로 변경
- 각 패키지의 homepage URL에서 중복된 `/docs` 제거

### 변경된 URL
- AS-IS: `naverpaydev.github.io/pie/docs/docs/@naverpay/xxx/`
- TO-BE: `naverpaydev.github.io/pie/docs/@naverpay/xxx/`

Closes #119