### PR TITLE
[#118] fix: docs 페이지 편집 링크 404 문제 수정

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -41,7 +41,12 @@ const config: Config = {
             {
                 docs: {
                     sidebarPath: './sidebars.ts',
-                    editUrl: (params) => `https://github.com/NaverPayDev/pie/tree/main/packages/${params.docPath}`,
+                    editUrl: (params) => {
+                        const docPath = params.docPath.startsWith('@naverpay/')
+                            ? params.docPath.replace('@naverpay/', '')
+                            : params.docPath
+                        return `https://github.com/NaverPayDev/pie/blob/main/packages/${docPath}`
+                    },
                 },
                 blog: {
                     showReadingTime: true,


### PR DESCRIPTION
## Summary
- editUrl에서 `@naverpay/` 프리픽스를 제거하여 올바른 GitHub 경로로 연결

### 변경 내용
```typescript
// AS-IS
editUrl: (params) => `https://github.com/NaverPayDev/pie/tree/main/packages/${params.docPath}`

// TO-BE
editUrl: (params) => {
    const docPath = params.docPath.startsWith('@naverpay/')
        ? params.docPath.replace('@naverpay/', '')
        : params.docPath
    return `https://github.com/NaverPayDev/pie/blob/main/packages/${docPath}`
}
```

Closes #118