### PR TITLE
feat: 외부 fork PR에 changeset 가이드 코멘트 자동 추가

### DIFF
--- a/.github/workflows/detect-changed-packages.yml
+++ b/.github/workflows/detect-changed-packages.yml
@@ -31,10 +31,11 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: 'detect changed packages'
-              uses: NaverPayDev/changeset-actions/detect-add@main
+              uses: NaverPayDev/changeset-actions/detect-add@feature/fork-guide
               with:
                   github_token: ${{ secrets.ACTION_TOKEN }}
                   packages_dir: packages,share
                   skip_label: skip-detect-change
                   skip_branches: main
                   formatting_script: pnpm run markdownlint:fix
+                  fork_guide_enabled: 'true'


### PR DESCRIPTION
## Summary
- 외부 fork에서 오는 PR에 대해 changeset 생성 방법을 안내하는 코멘트 자동 추가
- 기존 내부 PR의 자동 changeset 감지 기능은 그대로 유지

### 변경 내용

| PR 유형 | 동작 |
|---------|------|
| 내부 PR | 기존대로 자동 changeset 감지 및 생성 |
| Fork PR | 한글/영어로 changeset 생성 방법 안내 코멘트 추가 |

### Fork PR에 달리는 코멘트 예시

```markdown
## Changeset Guide for External Contributors

**한국어** | [English](#english)

### 한국어
외부 기여자분께 감사드립니다! 🎉
패키지에 변경사항이 있는 경우, changeset 파일을 수동으로 생성해주세요.
...

### English
Thank you for your contribution! 🎉
If your PR includes package changes, please create a changeset file manually.
...
```

### 배경
- 외부 fork 사용자는 `ACTION_TOKEN` 시크릿에 접근할 수 없어 자동 changeset 감지가 실패함
- 이를 해결하기 위해 fork PR에는 수동 changeset 생성 방법을 안내하는 코멘트를 자동으로 추가