### PR TITLE
[#214] react-pdf a태그 부모 요소 크기 설정

### DIFF
--- a/.changeset/hip-dancers-trade.md
+++ b/.changeset/hip-dancers-trade.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/react-pdf": patch
+---
+
+[#214] react-pdf a태그 부모 요소 크기 설정
+
+PR: [[#214] react-pdf a태그 부모 요소 크기 설정](https://github.com/NaverPayDev/pie/pull/215)

--- a/packages/react-pdf/src/components/layer/Annotation.module.scss
+++ b/packages/react-pdf/src/components/layer/Annotation.module.scss
@@ -14,9 +14,12 @@
  */
 
 .annotationLayer {
-    section {
-        position: absolute;
-    }
+    position: relative;
+}
+
+.annotationLayer section {
+    position: absolute;
+}
 
     .linkAnnotation > a,
     .buttonWidgetAnnotation.pushButton > a {

--- a/packages/react-pdf/src/components/layer/Annotation.module.scss
+++ b/packages/react-pdf/src/components/layer/Annotation.module.scss
@@ -26,7 +26,6 @@
         left: 0;
         width: 100%;
         height: 100%;
-        cursor: pointer;
     }
 
     .linkAnnotation > a,

--- a/packages/react-pdf/src/components/layer/Annotation.module.scss
+++ b/packages/react-pdf/src/components/layer/Annotation.module.scss
@@ -26,6 +26,7 @@
         left: 0;
         width: 100%;
         height: 100%;
+        cursor: pointer;
     }
 
     .linkAnnotation > a,

--- a/packages/react-pdf/src/components/layer/Annotation.module.scss
+++ b/packages/react-pdf/src/components/layer/Annotation.module.scss
@@ -27,8 +27,7 @@
         font-size: 1em;
         top: 0;
         left: 0;
-        width: 100%;
-        height: 100%;
+        cursor: pointer;
     }
 
     .linkAnnotation > a,

--- a/packages/react-pdf/src/components/layer/Annotation.tsx
+++ b/packages/react-pdf/src/components/layer/Annotation.tsx
@@ -42,8 +42,7 @@ export const AnnotationLayer = memo(function AnnotationLayer() {
                 /**
                  * rerender 전에 해당 layer를 초기화합니다.
                  */
-                const children = element.children
-                Array.from(children).map((el) => el.remove())
+                Array.from(element.children).forEach((el) => el.remove())
 
                 const viewport = page.getViewport({scale}).clone({dontFlip: true})
 
@@ -73,23 +72,22 @@ export const AnnotationLayer = memo(function AnnotationLayer() {
                     // Do nothing
                 })
 
-                if (children.length > 0 && children?.[0]) {
-                    const firstChildren = children[0] as HTMLElement
-                    firstChildren.style.position = 'absolute'
-                    firstChildren.style.width = Math.floor(viewport.width) + 'px'
-                    firstChildren.style.height = Math.floor(viewport.height) + 'px'
+                // element 크기 설정: SCSS에서 width: 100% / height: 100%는 부모 크기 기준
+                // 실제 픽셀 크기를 명시해야 a 태그 크기가 결정됨
+                // annotation layer 컨테이너의 크기를 viewport에 맞춰 설정하여 내부의 모든 a 태그가 올바른 클릭 영역을 가지도록 함
+                element.style.width = Math.floor(viewport.width) + 'px'
+                element.style.height = Math.floor(viewport.height) + 'px'
 
-                    const aTags = firstChildren.getElementsByTagName('a') as unknown as HTMLAnchorElement[]
+                const aTags = Array.from(element.getElementsByTagName('a'))
 
-                    if (aTags.length > 0) {
-                        for (const elem of aTags) {
-                            elem.style.position = 'absolute'
-                            elem.style.top = '0'
-                            elem.style.left = '0'
-                            elem.style.width = '100%'
-                            elem.style.height = '100%'
-                            elem.style.cursor = 'pointer'
-                        }
+                if (aTags.length > 0) {
+                    for (const elem of aTags as HTMLAnchorElement[]) {
+                        elem.style.position = 'absolute'
+                        elem.style.top = '0'
+                        elem.style.left = '0'
+                        elem.style.width = '100%'
+                        elem.style.height = '100%'
+                        elem.style.cursor = 'pointer'
                     }
                 }
             })

--- a/packages/react-pdf/src/components/layer/Annotation.tsx
+++ b/packages/react-pdf/src/components/layer/Annotation.tsx
@@ -75,6 +75,9 @@ export const AnnotationLayer = memo(function AnnotationLayer() {
                 // element 크기 설정: SCSS에서 width: 100% / height: 100%는 부모 크기 기준
                 // 실제 픽셀 크기를 명시해야 a 태그 크기가 결정됨
                 // annotation layer 컨테이너의 크기를 viewport에 맞춰 설정하여 내부의 모든 a 태그가 올바른 클릭 영역을 가지도록 함
+                element.style.position = 'absolute'
+                element.style.top = '0'
+                element.style.left = '0'
                 element.style.width = Math.floor(viewport.width) + 'px'
                 element.style.height = Math.floor(viewport.height) + 'px'
 

--- a/packages/react-pdf/src/components/layer/Annotation.tsx
+++ b/packages/react-pdf/src/components/layer/Annotation.tsx
@@ -76,8 +76,8 @@ export const AnnotationLayer = memo(function AnnotationLayer() {
                 if (children.length > 0 && children?.[0]) {
                     const firstChildren = children[0] as HTMLElement
                     firstChildren.style.position = 'absolute'
-                    firstChildren.style.width = viewport.width + 'px'
-                    firstChildren.style.height = viewport.height + 'px'
+                    firstChildren.style.width = Math.floor(viewport.width) + 'px'
+                    firstChildren.style.height = Math.floor(viewport.height) + 'px'
 
                     const aTags = firstChildren.getElementsByTagName('a') as unknown as HTMLAnchorElement[]
 

--- a/packages/react-pdf/src/components/layer/Annotation.tsx
+++ b/packages/react-pdf/src/components/layer/Annotation.tsx
@@ -76,6 +76,8 @@ export const AnnotationLayer = memo(function AnnotationLayer() {
                 if (children.length > 0 && children?.[0]) {
                     const firstChildren = children[0] as HTMLElement
                     firstChildren.style.position = 'absolute'
+                    firstChildren.style.width = viewport.width + 'px'
+                    firstChildren.style.height = viewport.height + 'px'
 
                     const aTags = firstChildren.getElementsByTagName('a') as unknown as HTMLAnchorElement[]
 
@@ -86,6 +88,7 @@ export const AnnotationLayer = memo(function AnnotationLayer() {
                             elem.style.left = '0'
                             elem.style.width = '100%'
                             elem.style.height = '100%'
+                            elem.style.cursor = 'pointer'
                         }
                     }
                 }

--- a/packages/react-pdf/src/components/layer/Annotation.tsx
+++ b/packages/react-pdf/src/components/layer/Annotation.tsx
@@ -72,24 +72,10 @@ export const AnnotationLayer = memo(function AnnotationLayer() {
                     // Do nothing
                 })
 
-                // element 크기 설정: SCSS에서 width: 100% / height: 100%는 부모 크기 기준
-                // 실제 픽셀 크기를 명시해야 a 태그 크기가 결정됨
-                // annotation layer 컨테이너의 크기를 viewport에 맞춰 설정하여 내부의 모든 a 태그가 올바른 클릭 영역을 가지도록 함
-                element.style.position = 'absolute'
-                element.style.top = '0'
-                element.style.left = '0'
-                element.style.width = Math.floor(viewport.width) + 'px'
-                element.style.height = Math.floor(viewport.height) + 'px'
-
                 const aTags = Array.from(element.getElementsByTagName('a'))
 
                 if (aTags.length > 0) {
                     for (const elem of aTags as HTMLAnchorElement[]) {
-                        elem.style.position = 'absolute'
-                        elem.style.top = '0'
-                        elem.style.left = '0'
-                        elem.style.width = '100%'
-                        elem.style.height = '100%'
                         elem.style.cursor = 'pointer'
                     }
                 }
@@ -102,5 +88,14 @@ export const AnnotationLayer = memo(function AnnotationLayer() {
         return null
     }
 
-    return <div ref={drawAnnotation} className={cx('annotationLayer')} />
+    return (
+        <div
+            ref={drawAnnotation}
+            className={cx('annotationLayer')}
+            style={{
+                width: page ? `${Math.floor(page.getViewport({scale}).width)}px` : '100%',
+                height: page ? `${Math.floor(page.getViewport({scale}).height)}px` : '100%',
+            }}
+        />
+    )
 })

--- a/packages/react-pdf/src/components/layer/Annotation.tsx
+++ b/packages/react-pdf/src/components/layer/Annotation.tsx
@@ -69,16 +69,10 @@ export const AnnotationLayer = memo(function AnnotationLayer() {
                 }
 
                 await new PdfAnnotationLayer(annotationLayerParameters).render(parameters).catch(() => {
-                    // Do nothing
+                    // PDF annotation rendering failed - silently ignore for now
                 })
 
-                const aTags = Array.from(element.getElementsByTagName('a'))
-
-                if (aTags.length > 0) {
-                    for (const elem of aTags as HTMLAnchorElement[]) {
-                        elem.style.cursor = 'pointer'
-                    }
-                }
+                // cursor: pointer는 SCSS에서 처리됨
             })
         },
         [annotations, pdfLinkService, page, scale],


### PR DESCRIPTION
## Related Issue <!-- #뒤에 이슈번호 작성 -->

- #214 

## Describe your changes <!-- PR의 주요 작업 내용 작성 -->

- Annotation.tsx 에서 drawAnnotation 함수 내에서 a 태그의 스타일을 직접 설정하는 부분 외에,
실제로 a 태그의 부모 요소 즉, firstChildren 에 width 와 height 가 설정되지 않아서 a 태그의 width: 100% 가 제대로 적용되지 않는 문제
- 부모 요소 크기 viewport 기반 명시적 설정 추가


## Request <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->

- 
