### PR TITLE
docs: CONTRIBUTING의 node/pnpm 버전 실제값으로 수정

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@
 
 ### 시스템 요구 사항
 
-- node: node@18.12.0 버전. `node -v` 명령어로 확인하실 수 있습니다.
-- pnpm: pnpm@8.6.6 버전. `pnpm -v` 명령어로 확인하실 수 있습니다.
+- node: `.nvmrc` 기준 node@22.11.0 버전. `node -v` 명령어로 확인하실 수 있습니다.
+- pnpm: `package.json`의 `packageManager` 기준 pnpm@10.5.2 버전. `pnpm -v` 명령어로 확인하실 수 있습니다.
 
 ### 개발
 


### PR DESCRIPTION
## 무엇을

`CONTRIBUTING.md`의 **시스템 요구 사항** 버전이 실제 레포 설정과 달라, 신입 기여자가 문서대로 환경을 세팅하면 CI와 어긋나는 문제를 수정합니다.

| 항목 | 기존(문서) | 변경(실제값) | 근거 |
|---|---|---|---|
| node | `18.12.0` | `22.11.0` | `.nvmrc` (CI도 Node 22 사용) |
| pnpm | `8.6.6` | `10.5.2` | `package.json`의 `packageManager` |

## 왜

신입 온보딩 중 발견했습니다. 문서의 node@18 / pnpm@8.6.6을 그대로 설치하면 `pnpm install --frozen-lockfile`이나 빌드 단계에서 CI(Node 22 / pnpm 10.5.2)와 동작이 달라질 수 있어, 진입 장벽이자 디버깅 비용으로 이어집니다.

## 범위

- 문서 2줄만 수정, 코드/패키지 변경 없음 → changeset 불필요
- 패키지 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)